### PR TITLE
Remove non-existent link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,6 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
 <a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>


### PR DESCRIPTION
The language folder "gi" does not exist. The correct language folder for Galician is "ga" (Galego).