### PR TITLE
add Vietnamese Translation pages

### DIFF
--- a/authors.html
+++ b/authors.html
@@ -52,8 +52,8 @@ Facilitator (CPF).
 </font></p>
 
 <p><font size="+1">
-<b>Alistair Cockburn</b>, founder of <A HREF="//members.aol.com/acockburn">
-Humans and Technology</A>, is known for his extensive interviews of project teams.
+<b>Alistair Cockburn</b>, founder of
+Humans and Technology, is known for his extensive interviews of project teams.
 These interviews, together with his active participation on live projects, form
 the basis for his methodology designs: light but sufficient, and self-evolving.
 Alistair's work in the 1990s grew into the Crystal family of agile methodologies.
@@ -117,8 +117,8 @@ a member of the ACM and IEEE.
 
 <p><font size="+1">
 <b>Ron Jeffries</b> is the proprietor of <a href="//www.XProgramming.com">
-XProgramming.com</a>, a consultant with <a href="//www.objectmentor.com">Object
-Mentor</a>, and the author (with Ann Anderson and Chet Hendrickson) of <i>Extreme
+XProgramming.com</a>, a consultant with Object
+Mentor, and the author (with Ann Anderson and Chet Hendrickson) of <i>Extreme
 Programming Installed</i>. Ron was the first Extreme Programming coach, and is a prolific
 contributor to the XP-related Internet groups, and a frequent speaker at software
 conferences.
@@ -144,7 +144,7 @@ of his web page.
 
 <p><font size="+1">
 <b>Robert C. Martin</b> has been a software professional since 1970.  He is
-president and founder of <a href=//www.objectmentor.com>Object Mentor Inc.</a>
+president and founder of Object Mentor Inc.
 a firm
 of highly experienced consultants who offer XP and agile process consulting,
 software design consulting, training, and development services to major

--- a/chart.html
+++ b/chart.html
@@ -1,1611 +1,1611 @@
 
 <center>
-<h1>Signatories of the Agile Manifesto</h1>
+<h1.html>Signatories of the Agile Manifesto</h1.html>
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000001>
+        <a href=/display/000000001.html>
             <img src=bucket.jpg width=189 height=22 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000002>
+        <a href=/display/000000002.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000003>
+        <a href=/display/000000003.html>
             <img src=bucket.jpg width=37 height=109 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000004>
+        <a href=/display/000000004.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000005>
+        <a href=/display/000000005.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000006>
+        <a href=/display/000000006.html>
             <img src=bucket.jpg width=39 height=103 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000007>
+        <a href=/display/000000007.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000008>
+        <a href=/display/000000008.html>
             <img src=bucket.jpg width=48 height=84 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000009>
+        <a href=/display/000000009.html>
             <img src=bucket.jpg width=76 height=51 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000010>
+        <a href=/display/000000010.html>
             <img src=bucket.jpg width=55 height=73 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000011>
+        <a href=/display/000000011.html>
             <img src=bucket.jpg width=54 height=75 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000012>
+        <a href=/display/000000012.html>
             <img src=bucket.jpg width=48 height=84 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000013>
+        <a href=/display/000000013.html>
             <img src=bucket.jpg width=46 height=87 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000014>
+        <a href=/display/000000014.html>
             <img src=bucket.jpg width=63 height=64 border=0>
         </a>
 </table>
 2002 (698 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000015>
+        <a href=/display/000000015.html>
             <img src=bucket.jpg width=57 height=71 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000016>
+        <a href=/display/000000016.html>
             <img src=bucket.jpg width=67 height=60 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000017>
+        <a href=/display/000000017.html>
             <img src=bucket.jpg width=48 height=84 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000018>
+        <a href=/display/000000018.html>
             <img src=bucket.jpg width=63 height=64 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000019>
+        <a href=/display/000000019.html>
             <img src=bucket.jpg width=45 height=89 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000020>
+        <a href=/display/000000020.html>
             <img src=bucket.jpg width=58 height=69 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000021>
+        <a href=/display/000000021.html>
             <img src=bucket.jpg width=49 height=82 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000022>
+        <a href=/display/000000022.html>
             <img src=bucket.jpg width=55 height=73 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000023>
+        <a href=/display/000000023.html>
             <img src=bucket.jpg width=43 height=94 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000024>
+        <a href=/display/000000024.html>
             <img src=bucket.jpg width=45 height=89 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000025>
+        <a href=/display/000000025.html>
             <img src=bucket.jpg width=66 height=61 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000026>
+        <a href=/display/000000026.html>
             <img src=bucket.jpg width=54 height=75 border=0>
         </a>
 </table>
 2003 (600 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000027>
+        <a href=/display/000000027.html>
             <img src=bucket.jpg width=165 height=25 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000028>
+        <a href=/display/000000028.html>
             <img src=bucket.jpg width=55 height=73 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000029>
+        <a href=/display/000000029.html>
             <img src=bucket.jpg width=51 height=79 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000030>
+        <a href=/display/000000030.html>
             <img src=bucket.jpg width=54 height=75 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000031>
+        <a href=/display/000000031.html>
             <img src=bucket.jpg width=55 height=73 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000032>
+        <a href=/display/000000032.html>
             <img src=bucket.jpg width=57 height=71 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000033>
+        <a href=/display/000000033.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000034>
+        <a href=/display/000000034.html>
             <img src=bucket.jpg width=54 height=75 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000035>
+        <a href=/display/000000035.html>
             <img src=bucket.jpg width=55 height=73 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000036>
+        <a href=/display/000000036.html>
             <img src=bucket.jpg width=45 height=89 border=0>
         </a>
 </table>
 2004 (500 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000037>
+        <a href=/display/000000037.html>
             <img src=bucket.jpg width=66 height=60 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000038>
+        <a href=/display/000000038.html>
             <img src=bucket.jpg width=43 height=94 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000039>
+        <a href=/display/000000039.html>
             <img src=bucket.jpg width=39 height=103 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000040>
+        <a href=/display/000000040.html>
             <img src=bucket.jpg width=39 height=103 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000041>
+        <a href=/display/000000041.html>
             <img src=bucket.jpg width=37 height=109 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000042>
+        <a href=/display/000000042.html>
             <img src=bucket.jpg width=39 height=103 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000043>
+        <a href=/display/000000043.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000044>
+        <a href=/display/000000044.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000045>
+        <a href=/display/000000045.html>
             <img src=bucket.jpg width=42 height=96 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000046>
+        <a href=/display/000000046.html>
             <img src=bucket.jpg width=54 height=75 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000047>
+        <a href=/display/000000047.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000048>
+        <a href=/display/000000048.html>
             <img src=bucket.jpg width=43 height=94 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000049>
+        <a href=/display/000000049.html>
             <img src=bucket.jpg width=49 height=81 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000050>
+        <a href=/display/000000050.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000051>
+        <a href=/display/000000051.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000052>
+        <a href=/display/000000052.html>
             <img src=bucket.jpg width=42 height=96 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000053>
+        <a href=/display/000000053.html>
             <img src=bucket.jpg width=39 height=103 border=0>
         </a>
 </table>
 2005 (848 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000054>
+        <a href=/display/000000054.html>
             <img src=bucket.jpg width=58 height=69 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000055>
+        <a href=/display/000000055.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000056>
+        <a href=/display/000000056.html>
             <img src=bucket.jpg width=40 height=101 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000057>
+        <a href=/display/000000057.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000058>
+        <a href=/display/000000058.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000059>
+        <a href=/display/000000059.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000060>
+        <a href=/display/000000060.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000061>
+        <a href=/display/000000061.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000062>
+        <a href=/display/000000062.html>
             <img src=bucket.jpg width=51 height=79 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000063>
+        <a href=/display/000000063.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000064>
+        <a href=/display/000000064.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000065>
+        <a href=/display/000000065.html>
             <img src=bucket.jpg width=37 height=109 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000066>
+        <a href=/display/000000066.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000067>
+        <a href=/display/000000067.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000068>
+        <a href=/display/000000068.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000069>
+        <a href=/display/000000069.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000070>
+        <a href=/display/000000070.html>
             <img src=bucket.jpg width=28 height=141 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000071>
+        <a href=/display/000000071.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000072>
+        <a href=/display/000000072.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000073>
+        <a href=/display/000000073.html>
             <img src=bucket.jpg width=33 height=119 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000074>
+        <a href=/display/000000074.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000075>
+        <a href=/display/000000075.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000076>
+        <a href=/display/000000076.html>
             <img src=bucket.jpg width=46 height=87 border=0>
         </a>
 </table>
 2006 (1148 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000077>
+        <a href=/display/000000077.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000078>
+        <a href=/display/000000078.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000079>
+        <a href=/display/000000079.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000080>
+        <a href=/display/000000080.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000081>
+        <a href=/display/000000081.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000082>
+        <a href=/display/000000082.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000083>
+        <a href=/display/000000083.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000084>
+        <a href=/display/000000084.html>
             <img src=bucket.jpg width=37 height=109 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000085>
+        <a href=/display/000000085.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000086>
+        <a href=/display/000000086.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000087>
+        <a href=/display/000000087.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000088>
+        <a href=/display/000000088.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000089>
+        <a href=/display/000000089.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000090>
+        <a href=/display/000000090.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000091>
+        <a href=/display/000000091.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000092>
+        <a href=/display/000000092.html>
             <img src=bucket.jpg width=37 height=109 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000093>
+        <a href=/display/000000093.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000094>
+        <a href=/display/000000094.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000095>
+        <a href=/display/000000095.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000096>
+        <a href=/display/000000096.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000097>
+        <a href=/display/000000097.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000098>
+        <a href=/display/000000098.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000099>
+        <a href=/display/000000099.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000100>
+        <a href=/display/000000100.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000101>
+        <a href=/display/000000101.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
 </table>
 2007 (1250 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000102>
+        <a href=/display/000000102.html>
             <img src=bucket.jpg width=39 height=103 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000103>
+        <a href=/display/000000103.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000104>
+        <a href=/display/000000104.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000105>
+        <a href=/display/000000105.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000106>
+        <a href=/display/000000106.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000107>
+        <a href=/display/000000107.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000108>
+        <a href=/display/000000108.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000109>
+        <a href=/display/000000109.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000110>
+        <a href=/display/000000110.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000111>
+        <a href=/display/000000111.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000112>
+        <a href=/display/000000112.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000113>
+        <a href=/display/000000113.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000114>
+        <a href=/display/000000114.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000115>
+        <a href=/display/000000115.html>
             <img src=bucket.jpg width=42 height=96 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000116>
+        <a href=/display/000000116.html>
             <img src=bucket.jpg width=12 height=334 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000117>
+        <a href=/display/000000117.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000118>
+        <a href=/display/000000118.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000119>
+        <a href=/display/000000119.html>
             <img src=bucket.jpg width=22 height=179 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000120>
+        <a href=/display/000000120.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000121>
+        <a href=/display/000000121.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000122>
+        <a href=/display/000000122.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000123>
+        <a href=/display/000000123.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000124>
+        <a href=/display/000000124.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000125>
+        <a href=/display/000000125.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000126>
+        <a href=/display/000000126.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000127>
+        <a href=/display/000000127.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000128>
+        <a href=/display/000000128.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000129>
+        <a href=/display/000000129.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000130>
+        <a href=/display/000000130.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000131>
+        <a href=/display/000000131.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000132>
+        <a href=/display/000000132.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000133>
+        <a href=/display/000000133.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000134>
+        <a href=/display/000000134.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
 </table>
 2008 (1649 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000135>
+        <a href=/display/000000135.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000136>
+        <a href=/display/000000136.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000137>
+        <a href=/display/000000137.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000138>
+        <a href=/display/000000138.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000139>
+        <a href=/display/000000139.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000140>
+        <a href=/display/000000140.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000141>
+        <a href=/display/000000141.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000142>
+        <a href=/display/000000142.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000143>
+        <a href=/display/000000143.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000144>
+        <a href=/display/000000144.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000145>
+        <a href=/display/000000145.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000146>
+        <a href=/display/000000146.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000147>
+        <a href=/display/000000147.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000148>
+        <a href=/display/000000148.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000149>
+        <a href=/display/000000149.html>
             <img src=bucket.jpg width=34 height=116 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000150>
+        <a href=/display/000000150.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000151>
+        <a href=/display/000000151.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000152>
+        <a href=/display/000000152.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000153>
+        <a href=/display/000000153.html>
             <img src=bucket.jpg width=18 height=223 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000154>
+        <a href=/display/000000154.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000155>
+        <a href=/display/000000155.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000156>
+        <a href=/display/000000156.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000157>
+        <a href=/display/000000157.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000158>
+        <a href=/display/000000158.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000159>
+        <a href=/display/000000159.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000160>
+        <a href=/display/000000160.html>
             <img src=bucket.jpg width=15 height=267 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000161>
+        <a href=/display/000000161.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000162>
+        <a href=/display/000000162.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000163>
+        <a href=/display/000000163.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000164>
+        <a href=/display/000000164.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000165>
+        <a href=/display/000000165.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000166>
+        <a href=/display/000000166.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000167>
+        <a href=/display/000000167.html>
             <img src=bucket.jpg width=39 height=103 border=0>
         </a>
 </table>
 2009 (1649 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000168>
+        <a href=/display/000000168.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000169>
+        <a href=/display/000000169.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000170>
+        <a href=/display/000000170.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000171>
+        <a href=/display/000000171.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000172>
+        <a href=/display/000000172.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000173>
+        <a href=/display/000000173.html>
             <img src=bucket.jpg width=10 height=401 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000174>
+        <a href=/display/000000174.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000175>
+        <a href=/display/000000175.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000176>
+        <a href=/display/000000176.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000177>
+        <a href=/display/000000177.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000178>
+        <a href=/display/000000178.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000179>
+        <a href=/display/000000179.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000180>
+        <a href=/display/000000180.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000181>
+        <a href=/display/000000181.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000182>
+        <a href=/display/000000182.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000183>
+        <a href=/display/000000183.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000184>
+        <a href=/display/000000184.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000185>
+        <a href=/display/000000185.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000186>
+        <a href=/display/000000186.html>
             <img src=bucket.jpg width=16 height=251 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000187>
+        <a href=/display/000000187.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000188>
+        <a href=/display/000000188.html>
             <img src=bucket.jpg width=37 height=109 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000189>
+        <a href=/display/000000189.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000190>
+        <a href=/display/000000190.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000191>
+        <a href=/display/000000191.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000192>
+        <a href=/display/000000192.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000193>
+        <a href=/display/000000193.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000194>
+        <a href=/display/000000194.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000195>
+        <a href=/display/000000195.html>
             <img src=bucket.jpg width=18 height=223 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000196>
+        <a href=/display/000000196.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000197>
+        <a href=/display/000000197.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
 </table>
 2010 (1500 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000198>
+        <a href=/display/000000198.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000199>
+        <a href=/display/000000199.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000200>
+        <a href=/display/000000200.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000201>
+        <a href=/display/000000201.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000202>
+        <a href=/display/000000202.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000203>
+        <a href=/display/000000203.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000204>
+        <a href=/display/000000204.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000205>
+        <a href=/display/000000205.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000206>
+        <a href=/display/000000206.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000207>
+        <a href=/display/000000207.html>
             <img src=bucket.jpg width=15 height=267 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000208>
+        <a href=/display/000000208.html>
             <img src=bucket.jpg width=16 height=251 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000209>
+        <a href=/display/000000209.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000210>
+        <a href=/display/000000210.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000211>
+        <a href=/display/000000211.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000212>
+        <a href=/display/000000212.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000213>
+        <a href=/display/000000213.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000214>
+        <a href=/display/000000214.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000215>
+        <a href=/display/000000215.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000216>
+        <a href=/display/000000216.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000217>
+        <a href=/display/000000217.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000218>
+        <a href=/display/000000218.html>
             <img src=bucket.jpg width=25 height=157 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000219>
+        <a href=/display/000000219.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000220>
+        <a href=/display/000000220.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000221>
+        <a href=/display/000000221.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000222>
+        <a href=/display/000000222.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000223>
+        <a href=/display/000000223.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000224>
+        <a href=/display/000000224.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000225>
+        <a href=/display/000000225.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000226>
+        <a href=/display/000000226.html>
             <img src=bucket.jpg width=28 height=141 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000227>
+        <a href=/display/000000227.html>
             <img src=bucket.jpg width=18 height=223 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000228>
+        <a href=/display/000000228.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000229>
+        <a href=/display/000000229.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000230>
+        <a href=/display/000000230.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000231>
+        <a href=/display/000000231.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000232>
+        <a href=/display/000000232.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
 </table>
 2011 (1748 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000233>
+        <a href=/display/000000233.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000234>
+        <a href=/display/000000234.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000235>
+        <a href=/display/000000235.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000236>
+        <a href=/display/000000236.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000237>
+        <a href=/display/000000237.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000238>
+        <a href=/display/000000238.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000239>
+        <a href=/display/000000239.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000240>
+        <a href=/display/000000240.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000241>
+        <a href=/display/000000241.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000242>
+        <a href=/display/000000242.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000243>
+        <a href=/display/000000243.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000244>
+        <a href=/display/000000244.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000245>
+        <a href=/display/000000245.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000246>
+        <a href=/display/000000246.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000247>
+        <a href=/display/000000247.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000248>
+        <a href=/display/000000248.html>
             <img src=bucket.jpg width=43 height=94 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000249>
+        <a href=/display/000000249.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000250>
+        <a href=/display/000000250.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000251>
+        <a href=/display/000000251.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000252>
+        <a href=/display/000000252.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000253>
+        <a href=/display/000000253.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000254>
+        <a href=/display/000000254.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000255>
+        <a href=/display/000000255.html>
             <img src=bucket.jpg width=40 height=101 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000256>
+        <a href=/display/000000256.html>
             <img src=bucket.jpg width=42 height=96 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000257>
+        <a href=/display/000000257.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000258>
+        <a href=/display/000000258.html>
             <img src=bucket.jpg width=33 height=122 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000259>
+        <a href=/display/000000259.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000260>
+        <a href=/display/000000260.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000261>
+        <a href=/display/000000261.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000262>
+        <a href=/display/000000262.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000263>
+        <a href=/display/000000263.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
 </table>
 2012 (1550 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000264>
+        <a href=/display/000000264.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000265>
+        <a href=/display/000000265.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000266>
+        <a href=/display/000000266.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000267>
+        <a href=/display/000000267.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000268>
+        <a href=/display/000000268.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000269>
+        <a href=/display/000000269.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000270>
+        <a href=/display/000000270.html>
             <img src=bucket.jpg width=34 height=118 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000271>
+        <a href=/display/000000271.html>
             <img src=bucket.jpg width=13 height=308 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000272>
+        <a href=/display/000000272.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000273>
+        <a href=/display/000000273.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000274>
+        <a href=/display/000000274.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000275>
+        <a href=/display/000000275.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000276>
+        <a href=/display/000000276.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000277>
+        <a href=/display/000000277.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000278>
+        <a href=/display/000000278.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000279>
+        <a href=/display/000000279.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000280>
+        <a href=/display/000000280.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000281>
+        <a href=/display/000000281.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000282>
+        <a href=/display/000000282.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000283>
+        <a href=/display/000000283.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000284>
+        <a href=/display/000000284.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000285>
+        <a href=/display/000000285.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000286>
+        <a href=/display/000000286.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000287>
+        <a href=/display/000000287.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000288>
+        <a href=/display/000000288.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000289>
+        <a href=/display/000000289.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000290>
+        <a href=/display/000000290.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000291>
+        <a href=/display/000000291.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000292>
+        <a href=/display/000000292.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000293>
+        <a href=/display/000000293.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000294>
+        <a href=/display/000000294.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000295>
+        <a href=/display/000000295.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000296>
+        <a href=/display/000000296.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000297>
+        <a href=/display/000000297.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
 </table>
 2013 (1700 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000298>
+        <a href=/display/000000298.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000299>
+        <a href=/display/000000299.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000300>
+        <a href=/display/000000300.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000301>
+        <a href=/display/000000301.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000302>
+        <a href=/display/000000302.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000303>
+        <a href=/display/000000303.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000304>
+        <a href=/display/000000304.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000305>
+        <a href=/display/000000305.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000306>
+        <a href=/display/000000306.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000307>
+        <a href=/display/000000307.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000308>
+        <a href=/display/000000308.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000309>
+        <a href=/display/000000309.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000310>
+        <a href=/display/000000310.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000311>
+        <a href=/display/000000311.html>
             <img src=bucket.jpg width=18 height=223 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000312>
+        <a href=/display/000000312.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000313>
+        <a href=/display/000000313.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000314>
+        <a href=/display/000000314.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000315>
+        <a href=/display/000000315.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000316>
+        <a href=/display/000000316.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000317>
+        <a href=/display/000000317.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000318>
+        <a href=/display/000000318.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000319>
+        <a href=/display/000000319.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000320>
+        <a href=/display/000000320.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000321>
+        <a href=/display/000000321.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000322>
+        <a href=/display/000000322.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000323>
+        <a href=/display/000000323.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000324>
+        <a href=/display/000000324.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000325>
+        <a href=/display/000000325.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000326>
+        <a href=/display/000000326.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000327>
+        <a href=/display/000000327.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000328>
+        <a href=/display/000000328.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000329>
+        <a href=/display/000000329.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000330>
+        <a href=/display/000000330.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000331>
+        <a href=/display/000000331.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000332>
+        <a href=/display/000000332.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
 </table>
 2014 (1750 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000333>
+        <a href=/display/000000333.html>
             <img src=bucket.jpg width=36 height=112 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000334>
+        <a href=/display/000000334.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000335>
+        <a href=/display/000000335.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000336>
+        <a href=/display/000000336.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000337>
+        <a href=/display/000000337.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000338>
+        <a href=/display/000000338.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000339>
+        <a href=/display/000000339.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000340>
+        <a href=/display/000000340.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000341>
+        <a href=/display/000000341.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000342>
+        <a href=/display/000000342.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000343>
+        <a href=/display/000000343.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000344>
+        <a href=/display/000000344.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000345>
+        <a href=/display/000000345.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000346>
+        <a href=/display/000000346.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000347>
+        <a href=/display/000000347.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000348>
+        <a href=/display/000000348.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000349>
+        <a href=/display/000000349.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000350>
+        <a href=/display/000000350.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000351>
+        <a href=/display/000000351.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000352>
+        <a href=/display/000000352.html>
             <img src=bucket.jpg width=31 height=130 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000353>
+        <a href=/display/000000353.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000354>
+        <a href=/display/000000354.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000355>
+        <a href=/display/000000355.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000356>
+        <a href=/display/000000356.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000357>
+        <a href=/display/000000357.html>
             <img src=bucket.jpg width=18 height=223 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000358>
+        <a href=/display/000000358.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000359>
+        <a href=/display/000000359.html>
             <img src=bucket.jpg width=18 height=223 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000360>
+        <a href=/display/000000360.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000361>
+        <a href=/display/000000361.html>
             <img src=bucket.jpg width=18 height=223 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000362>
+        <a href=/display/000000362.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000363>
+        <a href=/display/000000363.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000364>
+        <a href=/display/000000364.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000365>
+        <a href=/display/000000365.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000366>
+        <a href=/display/000000366.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000367>
+        <a href=/display/000000367.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000368>
+        <a href=/display/000000368.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000369>
+        <a href=/display/000000369.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
 </table>
 2015 (1850 signatures)
 <table><tr>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000370>
+        <a href=/display/000000370.html>
             <img src=bucket.jpg width=27 height=149 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000371>
+        <a href=/display/000000371.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000372>
+        <a href=/display/000000372.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000373>
+        <a href=/display/000000373.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000374>
+        <a href=/display/000000374.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000375>
+        <a href=/display/000000375.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000376>
+        <a href=/display/000000376.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000377>
+        <a href=/display/000000377.html>
             <img src=bucket.jpg width=28 height=143 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000378>
+        <a href=/display/000000378.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000379>
+        <a href=/display/000000379.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000380>
+        <a href=/display/000000380.html>
             <img src=bucket.jpg width=19 height=211 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000381>
+        <a href=/display/000000381.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000382>
+        <a href=/display/000000382.html>
             <img src=bucket.jpg width=24 height=167 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000383>
+        <a href=/display/000000383.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000384>
+        <a href=/display/000000384.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000385>
+        <a href=/display/000000385.html>
             <img src=bucket.jpg width=18 height=223 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000386>
+        <a href=/display/000000386.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000387>
+        <a href=/display/000000387.html>
             <img src=bucket.jpg width=25 height=161 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000388>
+        <a href=/display/000000388.html>
             <img src=bucket.jpg width=22 height=182 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000389>
+        <a href=/display/000000389.html>
             <img src=bucket.jpg width=21 height=191 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000390>
+        <a href=/display/000000390.html>
             <img src=bucket.jpg width=30 height=134 border=0>
         </a>
     <td valign=bottom>
-        <a href=display.cgi?ms=000000391>
+        <a href=/display/000000391.html>
             <img src=bucket.jpg width=10 height=113 border=0>
         </a>
 </table>
@@ -1615,11 +1615,11 @@
 <font color=gray>
 We collect signatures in buckets of up to fifty signatures each.
 In this chart we adjust the buckets so that the width is proportional
-to the days it took to record the signatures and the height is 
-proportional to the rate they were recorded. Click on a bucket to 
+to the days it took to record the signatures and the height is
+proportional to the rate they were recorded. Click on a bucket to
 see the signatures.
 </font>
 </table>
-<br><font color=gray size=-1>
+<br><font color=gray size=-1.html>
 &copy; 2005 Ward Cunningham
 </font>

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/index.html
+++ b/index.html
@@ -100,11 +100,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>български език</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -119,6 +120,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -127,12 +129,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -147,11 +148,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -166,8 +166,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@ iterative development, collaborative development,
 software engineering best practices, software development,
 best practices
 ">
+<link rel="canonical" href="/">
 </head>
 <body background="/background.jpg">
 <center>
@@ -99,19 +100,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
+<a href=/iso/bg/manifesto.html>български език</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +118,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +127,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +147,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +159,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -185,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/af/manifesto.html
+++ b/iso/af/manifesto.html
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 

--- a/iso/af/manifesto.html
+++ b/iso/af/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/af/manifesto.html
+++ b/iso/af/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/af/manifesto.html
+++ b/iso/af/manifesto.html
@@ -169,7 +169,7 @@ but only in its entirety through this notice.
 <br><br>
 
 <font size=1 color=gray>
-site design and artwork &copy; 2001, Ward Cunningham<br>Afrikaans translation by Casper du Plessis, with help from <a href="http://www.proofreading-sa.co.za//">Clean Text</a>. Afrikaans edits by Rossouw van Rooyen
+site design and artwork &copy; 2001, Ward Cunningham<br>Afrikaans translation by Casper du Plessis, with help from Clean Text. Afrikaans edits by Rossouw van Rooyen
 
 </font>
 

--- a/iso/af/manifesto.html
+++ b/iso/af/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ar/manifesto.html
+++ b/iso/ar/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ar/manifesto.html
+++ b/iso/ar/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ar/manifesto.html
+++ b/iso/ar/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ar/manifesto.html
+++ b/iso/ar/manifesto.html
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -185,4 +185,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/az/manifesto.html
+++ b/iso/az/manifesto.html
@@ -104,7 +104,7 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/az/manifesto.html
+++ b/iso/az/manifesto.html
@@ -99,19 +99,17 @@ bəyannamə istənilən formada köçürülə bilər
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,20 +158,21 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
 <font size=1 color=gray>
 saytın dizaynı və tərtibatı &copy; 2001, Ward Cunningham<br>
-Azərbaycanca tərcümə <a href="http://alii.pro" target="_blank">Əli İsmayılov</a> 
+Azərbaycanca tərcümə <a href="http://alii.pro" target="_blank">Əli İsmayılov</a>
 
 </font>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/az/manifesto.html
+++ b/iso/az/manifesto.html
@@ -99,11 +99,12 @@ bəyannamə istənilən formada köçürülə bilər
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/az/manifesto.html
+++ b/iso/az/manifesto.html
@@ -129,7 +129,7 @@ bəyannamə istənilən formada köçürülə bilər
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/be/manifesto.html
+++ b/iso/be/manifesto.html
@@ -94,19 +94,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -114,9 +112,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -125,10 +121,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -143,10 +141,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -154,14 +153,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -181,4 +181,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/be/manifesto.html
+++ b/iso/be/manifesto.html
@@ -99,7 +99,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/be/manifesto.html
+++ b/iso/be/manifesto.html
@@ -94,11 +94,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -113,6 +114,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -121,12 +123,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -141,11 +142,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -160,8 +160,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/be/manifesto.html
+++ b/iso/be/manifesto.html
@@ -167,7 +167,7 @@ but only in its entirety through this notice.
 
 <font size=1 color=gray>
 дызайн i афармленне сайту &copy; 2001, Ward Cunningham<br>
-Пераклад на беларускую <a href=mailto:krazumov@gmail.com> Ганны і Канстанціна Разумоўскіх </a> <br> пры падтрымцы <a href="http://www.agile.by">Agile Belarus</a> і <a href="http://wg.kamputerm.org/">Беларускай IT-тэрміналогіі</a>.
+Пераклад на беларускую <a href=mailto:krazumov@gmail.com> Ганны і Канстанціна Разумоўскіх </a> <br> пры падтрымцы <a href="http://www.agile.by">Agile Belarus</a> і Беларускай IT-тэрміналогіі.
 
 </font>
 

--- a/iso/be/manifesto.html
+++ b/iso/be/manifesto.html
@@ -124,7 +124,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/bg/manifesto.html
+++ b/iso/bg/manifesto.html
@@ -129,7 +129,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/bg/manifesto.html
+++ b/iso/bg/manifesto.html
@@ -99,19 +99,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/bg/manifesto.html
+++ b/iso/bg/manifesto.html
@@ -99,11 +99,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/bg/manifesto.html
+++ b/iso/bg/manifesto.html
@@ -104,7 +104,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/bs/manifesto.html
+++ b/iso/bs/manifesto.html
@@ -97,11 +97,12 @@ ali samo u cijelosti i uz ovu obavijest.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/bs/manifesto.html
+++ b/iso/bs/manifesto.html
@@ -102,7 +102,7 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/bs/manifesto.html
+++ b/iso/bs/manifesto.html
@@ -11,8 +11,8 @@ agile programming, agile development,
 extreme programming, XP, software project management,
 iterative development, collaborative development,
 software engineering best practices, software development,
-best practices, bosnian agilemanifesto, agilno programiranje, agilni razvoj  
-softvera, ektremno programiranje, 
+best practices, bosnian agilemanifesto, agilno programiranje, agilni razvoj
+softvera, ektremno programiranje,
 ">
 </head>
 <body background="/background.jpg">
@@ -97,19 +97,17 @@ ali samo u cijelosti i uz ovu obavijest.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/bs/manifesto.html
+++ b/iso/bs/manifesto.html
@@ -127,7 +127,7 @@ ali samo u cijelosti i uz ovu obavijest.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/by/manifesto.html
+++ b/iso/by/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html>Дванаццаць прынцыпаў шпаркага праграмавання</a><br><br><a href=/sign/signup.cgi>Дадай свой подпiс</a><br><a href=/sign/display.cgi>Глядзець хто падпiсаў</a><br><br><a href=/authors.html>Аб аўтарах</a><br><a href=/history.html>Пра Манiфест</a><br><a href="http://www.agilealliance.org/show/2548">Дапамажы нам перакласцi Манiфест</a>
+<a href=principles.html>Дванаццаць прынцыпаў шпаркага праграмавання</a><br><br><a href=/display/index.html>Глядзець хто падпiсаў</a><br><br><a href=/authors.html>Аб аўтарах</a><br><a href=/history.html>Пра Манiфест</a><br>
 </font>
 <br><br>
 

--- a/iso/by/manifesto.html
+++ b/iso/by/manifesto.html
@@ -70,7 +70,75 @@ Dave Thomas<br>
 <br><br>
 
 <font size="+2">
-<a href=/iso/ar>عربي</a><br><a href=/iso/bg>Български</a><br><a href=/iso/by>Беларуская</a><br><a href=/iso/ca>Català</a><br><a href=/iso/de>Deutsch</a><br><a href=/iso/en>English</a><br><a href=/iso/es>Español</a><br><a href=/iso/fr>Français</a><br><a href=/iso/he>עברית</a><br><a href=/iso/it>Italiano</a><br><a href=/iso/ja>日本語</a><br><a href=/iso/nl>Nederlands</a><br><a href=/iso/no>Norsk</a><br><a href=/iso/pl>Polski</a><br><a href=/iso/pr>فارسی</a><br><a href=/iso/ptbr>Português Brasileiro</a><br><a href=/iso/ptpt>Português Portugal</a><br><a href=/iso/sr>Srpski</a><br><a href=/iso/sv>Svenska</a><br><a href=/iso/zhcht>繁體中文</a><br>
+<a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/ar/manifesto.html>عربي</a><br>
+<a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
+<a href=/iso/be/manifesto.html>Беларуская</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/ca/manifesto.html>Català</a><br>
+<a href=/iso/cs/manifesto.html>Česky</a><br>
+<a href=/iso/de/manifesto.html>Deutsch</a><br>
+<a href=/iso/dk/manifesto.html>Dansk</a><br>
+<a href=/iso/el/manifesto.html>Ελληνικά</a><br>
+<a href=/>English</a><br>
+<a href=/iso/es/manifesto.html>Español</a><br>
+<a href=/iso/et/manifesto.html>Eesti</a><br>
+<a href=/iso/eu/manifesto.html>Euskara</a><br>
+<a href=/iso/fi/manifesto.html>Suomi</a><br>
+<a href=/iso/fr/manifesto.html>Français</a><br>
+<a href=/iso/ga/manifesto.html>Gaeilge</a><br>
+<a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
+<a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/he/manifesto.html>עברית</a><br>
+<a href=/iso/hi/manifesto.html>हिंदी</a><br>
+<a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
+<a href=/iso/hu/manifesto.html>Hungarian/Magyar</a><br>
+<a href=/iso/id/manifesto.html>Bahasa Indonesia</a><br>
+<a href=/iso/is/manifesto.html>Íslenska</a><br>
+<a href=/iso/it/manifesto.html>Italiano</a><br>
+<a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
+<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/ko/manifesto.html>한국어</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
+<a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
+<a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
+<a href=/iso/ne/manifesto.html>नेपाली</a><br>
+<a href=/iso/nl/manifesto.html>Nederlands</a><br>
+<a href=/iso/no/manifesto.html>Norsk</a><br>
+<a href=/iso/or/manifesto.html>ଓଡ଼ିଆ</a><br>
+<a href=/iso/pa/manifesto.html>ਪੰਜਾਬੀ</a><br>
+<a href=/iso/pl/manifesto.html>Polski</a><br>
+<a href=/iso/pr/manifesto.html>فارسی</a><br>
+<a href=/iso/ptbr/manifesto.html>Português Brasileiro</a><br>
+<a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
+<a href=/iso/ro/manifesto.html>Română</a><br>
+<a href=/iso/ru/manifesto.html>Русский</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sr/manifesto.html>Srpski</a><br>
+<a href=/iso/sv/manifesto.html>Svenska</a><br>
+<a href=/iso/sw/manifesto.html>Swahili</a><br>
+<a href=/iso/ta/manifesto.html>தமிழ்</a><br>
+<a href=/iso/te/manifesto.html>తెలుగు</a><br>
+<a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
+<a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
+<a href=/iso/tr/manifesto.html>Türkçe</a><br>
+<a href=/iso/ts/manifesto.html>Xitsonga</a><br>
+<a href=/iso/uk/manifesto.html>Українська</a><br>
+<a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
+<a href=/iso/yo/manifesto.html>Yoruba</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -88,4 +156,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/by/manifesto.html
+++ b/iso/by/manifesto.html
@@ -76,7 +76,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/by/manifesto.html
+++ b/iso/by/manifesto.html
@@ -101,7 +101,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/by/manifesto.html
+++ b/iso/by/manifesto.html
@@ -143,7 +143,7 @@ Dave Thomas<br>
 <br><br>
 
 <font size=1 color=gray>
-дызайн i афармленне сайту &copy; 2001, Ward Cunningham<br>Пераклад на беларускую <a href=mailto:krazumov@gmail.com> Ганны і Канстанціна Разумоўскіх </a> <br> пры падтрымцы <a href="http://www.agile.by">Agile Belarus</a> і <a href="http://wg.kamputerm.org/">Беларускай IT-тэрміналогіі</a>.
+дызайн i афармленне сайту &copy; 2001, Ward Cunningham<br>Пераклад на беларускую <a href=mailto:krazumov@gmail.com> Ганны і Канстанціна Разумоўскіх </a> <br> пры падтрымцы <a href="http://agile.by">Agile Belarus</a> і Беларускай IT-тэрміналогіі.
 </font>
 
 </center>

--- a/iso/by/manifesto.html
+++ b/iso/by/manifesto.html
@@ -71,11 +71,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -90,6 +91,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -98,12 +100,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -118,11 +119,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -137,8 +137,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ca/manifesto.html
+++ b/iso/ca/manifesto.html
@@ -6,14 +6,14 @@
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="Estem posant al descobert millors maneres de desenvolupar programari fent-ho i ajudant a altres a fer-ho.
-Aquests són els nostres principis i valors. 
+Aquests són els nostres principis i valors.
 ">
 <META name="keywords" content="manifestàgil agilealliance alliance manifest,
 programació àgil, desenvolupament àgil,
 programació extrema, XP, gestió de projectes de programari,
 desenvolupament iteratiu, desenvolupament col·laboratiu,
 millors pràctiques d'enginyeria de programari, desenvolupament de programari,
-millors pràctiques   
+millors pràctiques
 ">
 </head>
 <body background="/background.jpg">
@@ -29,7 +29,7 @@ millors pràctiques
 <font size="+2">
 Estem posant al descobert millors maneres de desenvolupar programari<br>
 fent-ho i ajudant a altres a fer-ho.<br>
-Mitjançant aquesta feina hem acabat valorant:<br> 
+Mitjançant aquesta feina hem acabat valorant:<br>
 
 </font>
 
@@ -99,19 +99,17 @@ però només de forma íntegra.<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ però només de forma íntegra.<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ però només de forma íntegra.<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ però només de forma íntegra.<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,19 +158,20 @@ però només de forma íntegra.<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
 <font size=1 color=gray>
-disseny del lloc i gràfics &copy; 2001, Ward Cunningham<br> 
+disseny del lloc i gràfics &copy; 2001, Ward Cunningham<br>
 traducció al català: José Raya, Xavier Albaladejo, Vicenç Garcia, Jordi Garcia i Eloi Nadal
 
 </font>
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ca/manifesto.html
+++ b/iso/ca/manifesto.html
@@ -129,7 +129,7 @@ però només de forma íntegra.<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ca/manifesto.html
+++ b/iso/ca/manifesto.html
@@ -99,11 +99,12 @@ però només de forma íntegra.<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ però només de forma íntegra.<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ però només de forma íntegra.<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ però només de forma íntegra.<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ però només de forma íntegra.<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ca/manifesto.html
+++ b/iso/ca/manifesto.html
@@ -104,7 +104,7 @@ però només de forma íntegra.<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/cs/manifesto.html
+++ b/iso/cs/manifesto.html
@@ -97,11 +97,12 @@ ale pouze v plném rozsahu včetně této poznámky.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/cs/manifesto.html
+++ b/iso/cs/manifesto.html
@@ -127,7 +127,7 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/cs/manifesto.html
+++ b/iso/cs/manifesto.html
@@ -8,7 +8,7 @@
 <META name="description" content="Objevujeme lepší způsoby vývoje software tím, že jej tvoříme a pomáháme při jeho tvorbě ostatním. Při této práci jsme dospěli k těmto hodnotám:
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
-agilní manifest, agilní programování, agilní vývoj, 
+agilní manifest, agilní programování, agilní vývoj,
 extrémní programování, XP, software project management,
 iterativní vývoj, spolupráce,
 software engineering best practices, softwarový vývoj,
@@ -41,7 +41,7 @@ Při této práci jsme dospěli k těmto hodnotám:<br>
 
 <p>
 <font size="+2">
-Jakkoliv jsou body napravo hodnotné,<br> 
+Jakkoliv jsou body napravo hodnotné,<br>
 bodů nalevo si ceníme více.<br>
 
 </font>
@@ -97,19 +97,17 @@ ale pouze v plném rozsahu včetně této poznámky.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/cs/manifesto.html
+++ b/iso/cs/manifesto.html
@@ -102,7 +102,7 @@ ale pouze v plném rozsahu včetně této poznámky.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/de/manifesto.html
+++ b/iso/de/manifesto.html
@@ -95,11 +95,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -114,6 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -122,12 +124,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -142,11 +143,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -161,8 +161,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/de/manifesto.html
+++ b/iso/de/manifesto.html
@@ -125,7 +125,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/de/manifesto.html
+++ b/iso/de/manifesto.html
@@ -95,19 +95,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -115,9 +113,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,10 +122,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,10 +142,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -155,14 +154,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -181,4 +181,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/de/manifesto.html
+++ b/iso/de/manifesto.html
@@ -100,7 +100,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/dk/manifesto.html
+++ b/iso/dk/manifesto.html
@@ -130,7 +130,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/dk/manifesto.html
+++ b/iso/dk/manifesto.html
@@ -6,7 +6,7 @@
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="Vi afdækker bedre måder at udvikle software på ved at
-gøre det og ved at hjælpe andre med at gøre det. 
+gøre det og ved at hjælpe andre med at gøre det.
 Gennem dette arbejde har vi lært at værdsætte følgende
 værdier og principper.
 ">
@@ -100,19 +100,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -120,9 +118,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -131,10 +127,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -149,10 +147,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -160,14 +159,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -187,4 +187,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/dk/manifesto.html
+++ b/iso/dk/manifesto.html
@@ -105,7 +105,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/dk/manifesto.html
+++ b/iso/dk/manifesto.html
@@ -100,11 +100,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -119,6 +120,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -127,12 +129,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -147,11 +148,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -166,8 +166,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/el/manifesto.html
+++ b/iso/el/manifesto.html
@@ -5,8 +5,8 @@
 <title>Μανιφέστο για την ευέλικτη ανάπτυξη λογισμικού
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="Ανακαλύπτουμε καλύτερους τρόπους ανάπτυξης λογισμικού στην πράξη 
-και βοηθάμε τους άλλους να κάνουν το ίδιο. 
+<META name="description" content="Ανακαλύπτουμε καλύτερους τρόπους ανάπτυξης λογισμικού στην πράξη
+και βοηθάμε τους άλλους να κάνουν το ίδιο.
 Αυτές είναι οι αξίες και οι αρχές μας.
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
@@ -30,7 +30,7 @@ best practices
 <font size="+2">
 Ανακαλύπτουμε καλύτερους τρόπους ανάπτυξης <br>
 λογισμικού στην πράξη και βοηθάμε τους άλλους να κάνουν το ίδιο. <br>
-Αυτή η δραστηριότητα μας έχει οδηγήσει στο να αξιολογούμε:<br> 
+Αυτή η δραστηριότητα μας έχει οδηγήσει στο να αξιολογούμε:<br>
 
 </font>
 
@@ -99,19 +99,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -174,29 +174,29 @@ but only in its entirety through this notice.
 site design and artwork &copy; 2001, Ward Cunningham <br>
 Greek translation coordinated by: Jiannis Georgiadis, Dimitris Maketas, Ioannis Nikolaou <br>
 Contributors/Reviewers (in alphabetical order):<br>
-Chris Aniftos,  
-Dimitris Anoudis, 
-Anthea Blana, 
-Alexander Chatzigeorgiou, 
-George Chatzigeorgiou, 
-Eleni Chourouzidou, 
-Kostantinos Christodoulou, 
-Peter Dalmaris, 
-Costas Economopoulos, 
-Alexander Facklis, 
-Jiannis Georgiadis,  
-Theofanis Giotis, 
-Anastasios Koutoumanos, 
-Kyriakos Kyriakatos, 
-Spyros Lambrinidis, 
-Dimitris Maketas, 
-Ioannis Nikolaou, 
-Eleni Salamani, 
-Fotis Sallas, 
-Diomidis Spinellis, 
-Dimitris Theodorou, 
-Maria Zianika, 
-Manolis Zoumpoulakis 
+Chris Aniftos,
+Dimitris Anoudis,
+Anthea Blana,
+Alexander Chatzigeorgiou,
+George Chatzigeorgiou,
+Eleni Chourouzidou,
+Kostantinos Christodoulou,
+Peter Dalmaris,
+Costas Economopoulos,
+Alexander Facklis,
+Jiannis Georgiadis,
+Theofanis Giotis,
+Anastasios Koutoumanos,
+Kyriakos Kyriakatos,
+Spyros Lambrinidis,
+Dimitris Maketas,
+Ioannis Nikolaou,
+Eleni Salamani,
+Fotis Sallas,
+Diomidis Spinellis,
+Dimitris Theodorou,
+Maria Zianika,
+Manolis Zoumpoulakis
 
 </font>
 
@@ -210,4 +210,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/el/manifesto.html
+++ b/iso/el/manifesto.html
@@ -99,11 +99,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/el/manifesto.html
+++ b/iso/el/manifesto.html
@@ -129,7 +129,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/el/manifesto.html
+++ b/iso/el/manifesto.html
@@ -104,7 +104,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/en/manifesto.html
+++ b/iso/en/manifesto.html
@@ -100,11 +100,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -119,6 +120,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -127,12 +129,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -147,11 +148,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -166,8 +166,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/en/manifesto.html
+++ b/iso/en/manifesto.html
@@ -130,7 +130,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/en/manifesto.html
+++ b/iso/en/manifesto.html
@@ -105,7 +105,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/en/manifesto.html
+++ b/iso/en/manifesto.html
@@ -5,6 +5,7 @@
 <title>Manifesto for Agile Software Development
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="canonical" href="/">
 <META name="description" content="We are uncovering better ways of developing software
 by doing it and helping others do it. These are our
 values and principles.
@@ -99,19 +100,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +118,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +127,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +147,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +159,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 

--- a/iso/en/principles.html
+++ b/iso/en/principles.html
@@ -3,6 +3,7 @@
 <HEAD>
 <title>Principles behind the Agile Manifesto</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="canonical" href="/principles.html">
 </HEAD>
 <BODY background="http://AgileManifesto.org/background.jpg">
 

--- a/iso/es/manifesto.html
+++ b/iso/es/manifesto.html
@@ -103,11 +103,12 @@ Ayúdanos a traducir el Manifiesto</a>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -122,6 +123,7 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,12 +132,11 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -150,11 +151,10 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -169,8 +169,8 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/es/manifesto.html
+++ b/iso/es/manifesto.html
@@ -133,7 +133,7 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/es/manifesto.html
+++ b/iso/es/manifesto.html
@@ -108,7 +108,7 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/es/manifesto.html
+++ b/iso/es/manifesto.html
@@ -6,15 +6,15 @@
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="Estamos descubriendo formas mejores de desarrollar
-software tanto por nuestra propia experiencia como 
-ayudando a terceros. Estos son nuestros valores y 
+software tanto por nuestra propia experiencia como
+ayudando a terceros. Estos son nuestros valores y
 principios.
 ">
 <META name="keywords" content="manifiestoagil agilealliance alliance manifiesto,
 programación ágil, desarrollo ágil,
 programación extrema, XP, gestión de proyectos software,
 desarrollo iterativo, desarrollo colaborativo,
-mejores prácticas en ingeniería de software, 
+mejores prácticas en ingeniería de software,
 desarrollo de software, mejores prácticas
 ">
 </head>
@@ -103,19 +103,17 @@ Ayúdanos a traducir el Manifiesto</a>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -123,9 +121,7 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -134,10 +130,12 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -152,10 +150,11 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,14 +162,15 @@ Ayúdanos a traducir el Manifiesto</a>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -190,4 +190,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/et/manifesto.html
+++ b/iso/et/manifesto.html
@@ -103,7 +103,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/et/manifesto.html
+++ b/iso/et/manifesto.html
@@ -128,7 +128,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/et/manifesto.html
+++ b/iso/et/manifesto.html
@@ -98,11 +98,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -117,6 +118,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -125,12 +127,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,11 +146,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -164,8 +164,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/et/manifesto.html
+++ b/iso/et/manifesto.html
@@ -98,19 +98,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -118,9 +116,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -129,10 +125,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -147,10 +145,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -158,14 +157,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -185,4 +185,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/et/manifesto.html
+++ b/iso/et/manifesto.html
@@ -171,7 +171,7 @@ but only in its entirety through this notice.
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-Estonian translation by <a href="http://www.indermitte.net">Ain Indermitte</a>, <a href="mailto:marek@kusmin.eu">Marek Kusmin</a> and <a href="http://www.linkedin.com/in/silvere">Silver Ernesaks</a>, with help from <a href="http://www.agile.ee/">Agile Estonia</a>.
+Estonian translation by <a href="http://www.indermitte.net">Ain Indermitte</a>, <a href="mailto:marek@kusmin.eu">Marek Kusmin</a> and <a href="http://www.linkedin.com/in/silvere">Silver Ernesaks</a>, with help from <a href="http://agile.ee/">Agile Estonia</a>.
 
 </font>
 

--- a/iso/eu/manifesto.html
+++ b/iso/eu/manifesto.html
@@ -104,7 +104,7 @@ baina bere osotasunean bakarrik.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/eu/manifesto.html
+++ b/iso/eu/manifesto.html
@@ -129,7 +129,7 @@ baina bere osotasunean bakarrik.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/eu/manifesto.html
+++ b/iso/eu/manifesto.html
@@ -99,11 +99,12 @@ baina bere osotasunean bakarrik.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ baina bere osotasunean bakarrik.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ baina bere osotasunean bakarrik.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ baina bere osotasunean bakarrik.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ baina bere osotasunean bakarrik.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/eu/manifesto.html
+++ b/iso/eu/manifesto.html
@@ -99,19 +99,17 @@ baina bere osotasunean bakarrik.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ baina bere osotasunean bakarrik.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ baina bere osotasunean bakarrik.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ baina bere osotasunean bakarrik.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,20 +158,21 @@ baina bere osotasunean bakarrik.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
 <font size=1 color=gray>
 gunearen diseinua eta grafikoak &copy; 2001, Ward Cunningham<br>
-Itzulpena: Iosu Arizkuren, Urko Azpiroz, Iñaki Idigoras.   
+Itzulpena: Iosu Arizkuren, Urko Azpiroz, Iñaki Idigoras.
 
 </font>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/fi/manifesto.html
+++ b/iso/fi/manifesto.html
@@ -169,7 +169,7 @@ but only in its entirety through this notice.
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-Finnish translation by <a href="http://lassekoskela.com">Lasse Koskela</a>, with help from <a href="http://agilefinland.com/">Agile Finland</a>.
+Finnish translation by <a href="http://www.lassekoskela.com">Lasse Koskela</a>, with help from <a href="http://agile.fi">Agile Finland</a>.
 
 </font>
 

--- a/iso/fi/manifesto.html
+++ b/iso/fi/manifesto.html
@@ -96,19 +96,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -116,9 +114,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -127,10 +123,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,10 +143,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -156,14 +155,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/fi/manifesto.html
+++ b/iso/fi/manifesto.html
@@ -101,7 +101,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/fi/manifesto.html
+++ b/iso/fi/manifesto.html
@@ -96,11 +96,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -115,6 +116,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -123,12 +125,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -143,11 +144,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -162,8 +162,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/fi/manifesto.html
+++ b/iso/fi/manifesto.html
@@ -126,7 +126,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/fr/manifesto.html
+++ b/iso/fr/manifesto.html
@@ -103,7 +103,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/fr/manifesto.html
+++ b/iso/fr/manifesto.html
@@ -128,7 +128,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/fr/manifesto.html
+++ b/iso/fr/manifesto.html
@@ -98,11 +98,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -117,6 +118,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -125,12 +127,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,11 +146,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -164,8 +164,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/fr/manifesto.html
+++ b/iso/fr/manifesto.html
@@ -12,8 +12,8 @@ agile programming, agile development,
 extreme programming, XP, software project management,
 iterative development, collaborative development,
 software engineering best practices, software development,
-best practices, développement Agile, développement 
-itératif, développement collaboratif 
+best practices, développement Agile, développement
+itératif, développement collaboratif
 ">
 </head>
 <body background="/background.jpg">
@@ -98,19 +98,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -118,9 +116,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -129,10 +125,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -147,10 +145,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -158,14 +157,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/fr/manifesto.html
+++ b/iso/fr/manifesto.html
@@ -171,7 +171,7 @@ but only in its entirety through this notice.
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-French translation by: <a href="http://clubagile.org/">Club Agile Rhône-Alpes</a>, Arnaud Pierrel, Bruno Orsier, Christophe Deniaud<br>
+French translation by: Club Agile Rhône-Alpes, Arnaud Pierrel, Bruno Orsier, Christophe Deniaud<br>
 Reviewers: Claude Aubry, François Beauregard, Laurent Bossavit, Nathalie Gilbert
 
 </font>

--- a/iso/ga/manifesto.html
+++ b/iso/ga/manifesto.html
@@ -95,11 +95,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -114,6 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -122,12 +124,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -142,11 +143,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -161,8 +161,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ga/manifesto.html
+++ b/iso/ga/manifesto.html
@@ -125,7 +125,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ga/manifesto.html
+++ b/iso/ga/manifesto.html
@@ -5,7 +5,7 @@
 <title>Forógra um Fhorbairt Bogearraí Agile
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="Tá modhanna níos fearr bogearraí a fhorbairt 
+<META name="description" content="Tá modhanna níos fearr bogearraí a fhorbairt
 á nochtadh againn trí fheidhmíocht na forbartha féin agus cabhrú le daoine eile é a dhéanamh. Is iad seo ár luachanna agus ár bprionsabail.
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
@@ -27,7 +27,7 @@ best practices
 <p>
 
 <font size="+2">
-Tá módhanna forbartha bogearraí níos deise á nochtadh<br> trí fheidhmíocht na forbartha féin agus cabhrú le daoine eile é a dhéanamh.<br> 'Sé toradh na hoibre seo dúinn-ne ná béim níos láidre a chur ar seo a leanas:<br> 
+Tá módhanna forbartha bogearraí níos deise á nochtadh<br> trí fheidhmíocht na forbartha féin agus cabhrú le daoine eile é a dhéanamh.<br> 'Sé toradh na hoibre seo dúinn-ne ná béim níos láidre a chur ar seo a leanas:<br>
 
 </font>
 
@@ -95,19 +95,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -115,9 +113,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,10 +122,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,10 +142,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -155,14 +154,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ga/manifesto.html
+++ b/iso/ga/manifesto.html
@@ -100,7 +100,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/gd/manifesto.html
+++ b/iso/gd/manifesto.html
@@ -94,19 +94,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -114,9 +112,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -125,10 +121,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -143,10 +141,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -154,14 +153,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -180,4 +180,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/gd/manifesto.html
+++ b/iso/gd/manifesto.html
@@ -99,7 +99,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/gd/manifesto.html
+++ b/iso/gd/manifesto.html
@@ -94,11 +94,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -113,6 +114,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -121,12 +123,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -141,11 +142,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -160,8 +160,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/gd/manifesto.html
+++ b/iso/gd/manifesto.html
@@ -124,7 +124,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/gl/manifesto.html
+++ b/iso/gl/manifesto.html
@@ -107,7 +107,7 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/gl/manifesto.html
+++ b/iso/gl/manifesto.html
@@ -102,11 +102,12 @@ Axúdanos a traducir o Manifesto</a>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -121,6 +122,7 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -129,12 +131,11 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -149,11 +150,10 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -168,8 +168,8 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/gl/manifesto.html
+++ b/iso/gl/manifesto.html
@@ -132,7 +132,7 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/gl/manifesto.html
+++ b/iso/gl/manifesto.html
@@ -6,8 +6,8 @@
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="Estamos descubrindo formas mellores de desenvolver
-software tanto pola nosa propia experiencia como 
-axudando a terceiros. Estos son os nosos valores e 
+software tanto pola nosa propia experiencia como
+axudando a terceiros. Estos son os nosos valores e
 principios.
 ">
 <META name="keywords" content="manifesto áxil agilealliance alliance manifesto,
@@ -30,7 +30,7 @@ desenvolvemento de software, mellores prácticas
 
 <font size="+2">
 Estamos descubrindo formas mellores de desenvolver<br>
-software tanto pola nosa propia experiencia como axudando a terceiros.<br> 
+software tanto pola nosa propia experiencia como axudando a terceiros.<br>
 A través de este traballo aprendemos a valorar:<br>
 
 </font>
@@ -102,19 +102,17 @@ Axúdanos a traducir o Manifesto</a>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -122,9 +120,7 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -133,10 +129,12 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -151,10 +149,11 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -162,14 +161,15 @@ Axúdanos a traducir o Manifesto</a>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -189,4 +189,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/he/manifesto.html
+++ b/iso/he/manifesto.html
@@ -172,7 +172,7 @@ Dave Thomas<br>
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-Hebrew translation by Danny (Danko) Kovatch, Inbar Oren and Elad Amit from <a href=http://www.agilesparks.com>agilesparks</a>.
+Hebrew translation by Danny (Danko) Kovatch, Inbar Oren and Elad Amit from <a href=https://www.agilesparks.com>agilesparks</a>.
 
 </font>
 

--- a/iso/he/manifesto.html
+++ b/iso/he/manifesto.html
@@ -129,7 +129,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/he/manifesto.html
+++ b/iso/he/manifesto.html
@@ -99,19 +99,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/he/manifesto.html
+++ b/iso/he/manifesto.html
@@ -99,11 +99,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/he/manifesto.html
+++ b/iso/he/manifesto.html
@@ -104,7 +104,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/hi/manifesto.html
+++ b/iso/hi/manifesto.html
@@ -94,7 +94,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/hi/manifesto.html
+++ b/iso/hi/manifesto.html
@@ -119,7 +119,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/hi/manifesto.html
+++ b/iso/hi/manifesto.html
@@ -89,19 +89,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -109,9 +107,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -120,10 +116,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -138,10 +136,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -149,14 +148,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -175,4 +175,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/hi/manifesto.html
+++ b/iso/hi/manifesto.html
@@ -89,11 +89,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -108,6 +109,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -116,12 +118,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -136,11 +137,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -155,8 +155,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/hr/manifesto.html
+++ b/iso/hr/manifesto.html
@@ -5,15 +5,15 @@
 <title>Proglas o metodi agilnog razvoja softvera
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="Tražimo bolje načine razvoja softvera 
+<META name="description" content="Tražimo bolje načine razvoja softvera
 razvijajući softver i pomažući drugima pri njegovom razvoju.
-Takvim radom smo naučili da više cijenimo: 
+Takvim radom smo naučili da više cijenimo:
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
 agilni razvoj, agilno programiranje, žustri razvoj, žustro programiranje,
 ekstremno programiranje, razvoj softvera, upravljanje razvojem softvera,
-iterativno programiranje, suradni razvoj, 
-dobra praksa razvoja softvera, razvoj softvera, 
+iterativno programiranje, suradni razvoj,
+dobra praksa razvoja softvera, razvoj softvera,
 dobra praksa
 ">
 </head>
@@ -99,19 +99,17 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -187,4 +187,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/hr/manifesto.html
+++ b/iso/hr/manifesto.html
@@ -129,7 +129,7 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/hr/manifesto.html
+++ b/iso/hr/manifesto.html
@@ -104,7 +104,7 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/hr/manifesto.html
+++ b/iso/hr/manifesto.html
@@ -99,11 +99,12 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ ali samo u cijelosti, uključujući i ovu obavijest.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/hu/manifesto.html
+++ b/iso/hu/manifesto.html
@@ -123,7 +123,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/hu/manifesto.html
+++ b/iso/hu/manifesto.html
@@ -98,7 +98,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/hu/manifesto.html
+++ b/iso/hu/manifesto.html
@@ -4,7 +4,7 @@
 <title>Kiáltvány az agilis szoftverfejlesztésért
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="A szoftverfejlesztés hatékonyabb módját tárjuk fel saját tevékenységünk </b> és a másoknak nyújtott segítség útján. Ezek a mi értékeink és elveink. 
+<META name="description" content="A szoftverfejlesztés hatékonyabb módját tárjuk fel saját tevékenységünk </b> és a másoknak nyújtott segítség útján. Ezek a mi értékeink és elveink.
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
 agile programming, agile development,
@@ -93,19 +93,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -113,9 +111,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,10 +120,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -142,10 +140,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -153,14 +152,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -179,4 +179,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/hu/manifesto.html
+++ b/iso/hu/manifesto.html
@@ -93,11 +93,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -112,6 +113,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -120,12 +122,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -140,11 +141,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,8 +159,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/id/manifesto.html
+++ b/iso/id/manifesto.html
@@ -103,7 +103,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/id/manifesto.html
+++ b/iso/id/manifesto.html
@@ -128,7 +128,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/id/manifesto.html
+++ b/iso/id/manifesto.html
@@ -98,11 +98,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -117,6 +118,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -125,12 +127,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,11 +146,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -164,8 +164,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/id/manifesto.html
+++ b/iso/id/manifesto.html
@@ -98,19 +98,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -118,9 +116,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -129,10 +125,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -147,10 +145,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -158,14 +157,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -185,4 +185,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ind/manifesto.html
+++ b/iso/ind/manifesto.html
@@ -76,7 +76,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ind/manifesto.html
+++ b/iso/ind/manifesto.html
@@ -101,7 +101,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ind/manifesto.html
+++ b/iso/ind/manifesto.html
@@ -71,11 +71,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -90,6 +91,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -98,12 +100,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -118,11 +119,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -137,8 +137,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ind/manifesto.html
+++ b/iso/ind/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-<a href=Prinsip.html>Dua Belas Prinsip Perangkat Lunak Agile</a><br><br><a href=/sign/signup.cgi>Menjadi Pengunjung</a><br><a href=/sign/display.cgi>Lihat Pengunjung</a><br><br><a href=/Penulis.html>Tentang Penulis</a><br><a href=/sejarah.html>Tentang Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Bantu kami menerjemahkan Manifesto</a>
+<a href=principles.html>Dua Belas Prinsip Perangkat Lunak Agile</a><br><br><a href=/display/index.html>Lihat Pengunjung</a><br><br>
 </font>
 <br><br>
 

--- a/iso/ind/manifesto.html
+++ b/iso/ind/manifesto.html
@@ -70,7 +70,75 @@ Dave Thomas<br>
 <br><br>
 
 <font size="+2">
-<a href=/iso/af>Afrikaans</a><br><a href=/iso/sq>Albanian</a><br><a href=/iso/ar>عربي</a><br><a href=/iso/az>Azərbaycanca</a><br><a href=/iso/be>Беларуская</a><br><a href=/iso/bg>Български</a><br><a href=/iso/ca>Català</a><br><a href=/iso/cs>Česky</a><br><a href=/iso/de>Deutsch</a><br><a href=/iso/dk>Dansk</a><br><a href=/iso/el>Ελληνικά</a><br><a href=/iso/en>English</a><br><a href=/iso/es>Español</a><br><a href=/iso/et>Eesti</a><br><a href=/iso/eu>Euskara</a><br><a href=/iso/fi>Suomi</a><br><a href=/iso/fr>Français</a><br><a href=/iso/ka>ქართული</a><br><a href=/iso/he>עברית</a><br><a href=/iso/hi>हिंदी</a><br><a href=/iso/hr>Croatian/Hrvatski</a><br><a href=/iso/hu>Hungarian/Magyar</a><br><a href=/iso/id>Bahasa Indonesia</a><br><a href=/iso/is>Íslenska</a><br><a href=/iso/it>Italiano</a><br><a href=/iso/ja>日本語</a><br><a href=/iso/km>Khmer</a><br><a href=/iso/ko>한국어</a><br><a href=/iso/lv>Latviešu</a><br><a href=/iso/lt>Lietuvių</a><br><a href=/iso/mk>Македонски/Macedonian</a><br><a href=/iso/ms>Bahasa Melayu</a><br><a href=/iso/nl>Nederlands</a><br><a href=/iso/no>Norsk</a><br><a href=/iso/pl>Polski</a><br><a href=/iso/pr>فارسی</a><br><a href=/iso/ptbr>Português Brasileiro</a><br><a href=/iso/ptpt>Português Portugal</a><br><a href=/iso/ro>Română</a><br><a href=/iso/ru>Русский</a><br><a href=/iso/sl>Slovenščina</a><br><a href=/iso/sk>Slovensky</a><br><a href=/iso/sa>संस्कृत</a><br><a href=/iso/sr>Srpski</a><br><a href=/iso/sv>Svenska</a><br><a href=/iso/te>తెలుగు</a><br><a href=/iso/th>ภาษาไทย</a><br><a href=/iso/tl>Filipino</a><br><a href=/iso/tr>Türkçe</a><br><a href=/iso/ts>Xitsonga</a><br><a href=/iso/uk>Українська</a><br><a href=/iso/ur>اردو</a><br><a href=/iso/yo>Yoruba</a><br><a href=/iso/zhcht>繁體中文</a><br><a href=/iso/zhchs>简体中文</a><br>
+<a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/ar/manifesto.html>عربي</a><br>
+<a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
+<a href=/iso/be/manifesto.html>Беларуская</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/ca/manifesto.html>Català</a><br>
+<a href=/iso/cs/manifesto.html>Česky</a><br>
+<a href=/iso/de/manifesto.html>Deutsch</a><br>
+<a href=/iso/dk/manifesto.html>Dansk</a><br>
+<a href=/iso/el/manifesto.html>Ελληνικά</a><br>
+<a href=/>English</a><br>
+<a href=/iso/es/manifesto.html>Español</a><br>
+<a href=/iso/et/manifesto.html>Eesti</a><br>
+<a href=/iso/eu/manifesto.html>Euskara</a><br>
+<a href=/iso/fi/manifesto.html>Suomi</a><br>
+<a href=/iso/fr/manifesto.html>Français</a><br>
+<a href=/iso/ga/manifesto.html>Gaeilge</a><br>
+<a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
+<a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/he/manifesto.html>עברית</a><br>
+<a href=/iso/hi/manifesto.html>हिंदी</a><br>
+<a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
+<a href=/iso/hu/manifesto.html>Hungarian/Magyar</a><br>
+<a href=/iso/id/manifesto.html>Bahasa Indonesia</a><br>
+<a href=/iso/is/manifesto.html>Íslenska</a><br>
+<a href=/iso/it/manifesto.html>Italiano</a><br>
+<a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
+<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/ko/manifesto.html>한국어</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
+<a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
+<a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
+<a href=/iso/ne/manifesto.html>नेपाली</a><br>
+<a href=/iso/nl/manifesto.html>Nederlands</a><br>
+<a href=/iso/no/manifesto.html>Norsk</a><br>
+<a href=/iso/or/manifesto.html>ଓଡ଼ିଆ</a><br>
+<a href=/iso/pa/manifesto.html>ਪੰਜਾਬੀ</a><br>
+<a href=/iso/pl/manifesto.html>Polski</a><br>
+<a href=/iso/pr/manifesto.html>فارسی</a><br>
+<a href=/iso/ptbr/manifesto.html>Português Brasileiro</a><br>
+<a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
+<a href=/iso/ro/manifesto.html>Română</a><br>
+<a href=/iso/ru/manifesto.html>Русский</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sr/manifesto.html>Srpski</a><br>
+<a href=/iso/sv/manifesto.html>Svenska</a><br>
+<a href=/iso/sw/manifesto.html>Swahili</a><br>
+<a href=/iso/ta/manifesto.html>தமிழ்</a><br>
+<a href=/iso/te/manifesto.html>తెలుగు</a><br>
+<a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
+<a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
+<a href=/iso/tr/manifesto.html>Türkçe</a><br>
+<a href=/iso/ts/manifesto.html>Xitsonga</a><br>
+<a href=/iso/uk/manifesto.html>Українська</a><br>
+<a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
+<a href=/iso/yo/manifesto.html>Yoruba</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -88,4 +156,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/is/manifesto.html
+++ b/iso/is/manifesto.html
@@ -170,7 +170,7 @@ but only in its entirety through this notice.
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-Icelandic translation by <a href="http://www.sprettur.is/">Daði Ingólfsson and Pétur Orri Sæmundsen</a>, with help from <a href="http://www.agile.is/">Icelandic Agile User Group (Agile netið)</a>.
+Icelandic translation by <a href="http://www.sprettur.is/">Daði Ingólfsson and Pétur Orri Sæmundsen</a>, with help from <a href="http://www.agilenetid.is/">Icelandic Agile User Group (Agile netið)</a>.
 
 </font>
 

--- a/iso/is/manifesto.html
+++ b/iso/is/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/is/manifesto.html
+++ b/iso/is/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/is/manifesto.html
+++ b/iso/is/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/is/manifesto.html
+++ b/iso/is/manifesto.html
@@ -5,7 +5,7 @@
 <title>Stefnuyfirlýsing fyrir Agile hugbúnaðarþróun
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="Við leitum betri leiða til að þróa hugbúnað með því að þróa hann og aðstoða aðra við það. 
+<META name="description" content="Við leitum betri leiða til að þróa hugbúnað með því að þróa hann og aðstoða aðra við það.
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
 agile programming, agile development,
@@ -27,7 +27,7 @@ best practices
 
 <font size="+2">
 Við leitum betri leiða til að þróa hugbúnað<br/>
-með því að þróa hann og aðstoða aðra við það.<br/> 
+með því að þróa hann og aðstoða aðra við það.<br/>
 Með þessari vinnu höfum við lært að meta:<br/>
 
 </font>
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -184,4 +184,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/it/manifesto.html
+++ b/iso/it/manifesto.html
@@ -104,7 +104,7 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/it/manifesto.html
+++ b/iso/it/manifesto.html
@@ -172,7 +172,7 @@ purché sia inclusa questa stessa nota.
 
 <font size=1 color=gray>
 progettato da &copy; 2001, Ward Cunningham<br>
-Traduzione italiana di <a href="http://www.sviluppoagile.it/">Jacopo Romei</a>, <a href="http://www.agilesensei.com/">Claudio Perrone</a>, <a href="http://giordano.scalzo.biz/">Giordano Scalzo</a>, Lorenzo Urbini e <a href="http://www.open-ware.org/ita/home.htm">Fabio Armani</a>.<br>Revisioni effettuate in collaborazione con Alberto Brandolini, Simone Casciaroli, <a href="http://www.andreafrancia.it/">Andrea Francia</a>, Gabriele Lana, <a href="http://andreaprovaglio.com/">Andrea Provaglio</a> e Matteo Vaccari.
+Traduzione italiana di <a href="http://www.sviluppoagile.it/">Jacopo Romei</a>, <a href="https://agilesensei.com/">Claudio Perrone</a>, Giordano Scalzo, Lorenzo Urbini e <a href="http://www.open-ware.org">Fabio Armani</a>.<br>Revisioni effettuate in collaborazione con Alberto Brandolini, Simone Casciaroli, <a href="http://andreafrancia.it/">Andrea Francia</a>, Gabriele Lana, <a href="http://andreaprovaglio.com/">Andrea Provaglio</a> e Matteo Vaccari.
 
 </font>
 

--- a/iso/it/manifesto.html
+++ b/iso/it/manifesto.html
@@ -129,7 +129,7 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/it/manifesto.html
+++ b/iso/it/manifesto.html
@@ -99,11 +99,12 @@ purché sia inclusa questa stessa nota.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/it/manifesto.html
+++ b/iso/it/manifesto.html
@@ -13,8 +13,8 @@ Questi sono i nostri valori e principi.
 agile programming, agile development,
 extreme programming, XP, software project management,
 software engineering best practices, software development,
-best practices, programmazione, collaborazione, 
-manifesto agile, ingegneria del software, 
+best practices, programmazione, collaborazione,
+manifesto agile, ingegneria del software,
 gestione progetti, iterativo, incrementale
 ">
 </head>
@@ -99,19 +99,17 @@ purché sia inclusa questa stessa nota.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ purché sia inclusa questa stessa nota.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ja/manifesto.html
+++ b/iso/ja/manifesto.html
@@ -106,7 +106,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ja/manifesto.html
+++ b/iso/ja/manifesto.html
@@ -101,11 +101,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -120,6 +121,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,12 +130,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,11 +149,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -167,8 +167,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ja/manifesto.html
+++ b/iso/ja/manifesto.html
@@ -131,7 +131,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ja/manifesto.html
+++ b/iso/ja/manifesto.html
@@ -101,19 +101,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -121,9 +119,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -132,10 +128,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -150,10 +148,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -161,14 +160,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -188,4 +188,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ka/manifesto.html
+++ b/iso/ka/manifesto.html
@@ -97,7 +97,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ka/manifesto.html
+++ b/iso/ka/manifesto.html
@@ -21,7 +21,7 @@
 <p>
 
 <font size="+2">
-ჩვენ ვიღწვით პროგრამული უზრუნველყოფის შექმნის უკეთესი გზების აღმოსაჩენად,<br> 
+ჩვენ ვიღწვით პროგრამული უზრუნველყოფის შექმნის უკეთესი გზების აღმოსაჩენად,<br>
 ვქმნით თავად პროგრამულ უზრუნველყოფას და ვეხმარებით ამაში სხვებს.<br>
 ამ მოღვაწეობის შედეგად მივედით ღირებულებების შემდეგ სისტემამდე:<br>
 
@@ -36,7 +36,7 @@
 
 <p>
 <font size="+2">
-ამიტომაც, მიუხედავად იმისა, რომ ვაფასებთ მარჯვენა მხარეს მდგომ<br> 
+ამიტომაც, მიუხედავად იმისა, რომ ვაფასებთ მარჯვენა მხარეს მდგომ<br>
 ღირებულებებს, უპირატესობას ვანიჭებთ მარცხნივ მდგომებს.<br>
 
 </font>
@@ -77,7 +77,7 @@ Dave Thomas<br>
 <font size=1 color=gray>
 &copy; 2001, საავტორო უფლებები ეკუთვნის ზემოთ ჩამოთვლილ ავტორთა ჯგუფს.<br>
 დეკლარაციის გავრცელება ნებადართულია ნებისმიერი ფორმით<br>
-ამ შენიშვნის შენარჩუნების პირობით. 
+ამ შენიშვნის შენარჩუნების პირობით.
 
 </font>
 <br><br>
@@ -92,19 +92,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -112,9 +110,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -123,10 +119,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -141,10 +139,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -152,14 +151,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -179,4 +179,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ka/manifesto.html
+++ b/iso/ka/manifesto.html
@@ -92,11 +92,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -111,6 +112,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -119,12 +121,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -139,11 +140,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -158,8 +158,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ka/manifesto.html
+++ b/iso/ka/manifesto.html
@@ -122,7 +122,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ka/manifesto.html
+++ b/iso/ka/manifesto.html
@@ -165,7 +165,7 @@ Dave Thomas<br>
 
 <font size=1 color=gray>
 გვერდის დიზაინი და გაფორმება ეკუთვნის &copy; 2001, უორდ ქანინგჰემს (Ward Cunningham)<br>
-ქართული თარგმანის ავტორები: <a href="http://sites.google.com/site/gmamaladze">გიორგი მამალაძე</a>, ნათია თავართქილაძე, რატი ძიძიგური.
+ქართული თარგმანის ავტორები: <a href="https://sites.google.com/site/gmamaladze/">გიორგი მამალაძე</a>, ნათია თავართქილაძე, რატი ძიძიგური.
 
 </font>
 

--- a/iso/kk/manifesto.html
+++ b/iso/kk/manifesto.html
@@ -70,7 +70,75 @@ Dave Thomas<br>
 <br><br>
 
 <font size="+2">
-<a href=/iso/af>Afrikaans</a><br><a href=/iso/sq>Albanian</a><br><a href=/iso/ar>عربي</a><br><a href=/iso/az>Azərbaycanca</a><br><a href=/iso/be>Беларуская</a><br><a href=/iso/bs>Bosanski</a><br><a href=/iso/bg>Български</a><br><a href=/iso/ca>Català</a><br><a href=/iso/cs>Česky</a><br><a href=/iso/de>Deutsch</a><br><a href=/iso/dk>Dansk</a><br><a href=/iso/el>Ελληνικά</a><br><a href=/iso/en>English</a><br><a href=/iso/es>Español</a><br><a href=/iso/et>Eesti</a><br><a href=/iso/eu>Euskara</a><br><a href=/iso/fi>Suomi</a><br><a href=/iso/fr>Français</a><br><a href=/iso/ga>Gaeilge</a><br><a href=/iso/gd>Gàidhlig</a><br><a href=/iso/gl>Galego</a><br><a href=/iso/ka>ქართული</a><br><a href=/iso/kk>Қазақша</a><br><a href=/iso/he>עברית</a><br><a href=/iso/hi>हिंदी</a><br><a href=/iso/hr>Croatian/Hrvatski</a><br><a href=/iso/hu>Hungarian/Magyar</a><br><a href=/iso/id>Bahasa Indonesia</a><br><a href=/iso/is>Íslenska</a><br><a href=/iso/it>Italiano</a><br><a href=/iso/ja>日本語</a><br><a href=/iso/ko>한국어</a><br><a href=/iso/lv>Latviešu</a><br><a href=/iso/lt>Lietuvių</a><br><a href=/iso/mk>Македонски/Macedonian</a><br><a href=/iso/ms>Bahasa Melayu</a><br><a href=/iso/nl>Nederlands</a><br><a href=/iso/no>Norsk</a><br><a href=/iso/or>ଓଡ଼ିଆ</a><br><a href=/iso/pl>Polski</a><br><a href=/iso/pr>فارسی</a><br><a href=/iso/ptbr>Português Brasileiro</a><br><a href=/iso/ptpt>Português Portugal</a><br><a href=/iso/ro>Română</a><br><a href=/iso/ru>Русский</a><br><a href=/iso/sl>Slovenščina</a><br><a href=/iso/sk>Slovensky</a><br><a href=/iso/sa>संस्कृत</a><br><a href=/iso/sr>Srpski</a><br><a href=/iso/sv>Svenska</a><br><a href=/iso/ta>தமிழ்</a><br><a href=/iso/te>తెలుగు</a><br><a href=/iso/th>ภาษาไทย</a><br><a href=/iso/tl>Filipino</a><br><a href=/iso/tr>Türkçe</a><br><a href=/iso/ts>Xitsonga</a><br><a href=/iso/uk>Українська</a><br><a href=/iso/ur>اردو</a><br><a href=/iso/yo>Yoruba</a><br><a href=/iso/zhcht>繁體中文</a><br><a href=/iso/zhchs>简体中文</a><br>
+<a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/ar/manifesto.html>عربي</a><br>
+<a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
+<a href=/iso/be/manifesto.html>Беларуская</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/ca/manifesto.html>Català</a><br>
+<a href=/iso/cs/manifesto.html>Česky</a><br>
+<a href=/iso/de/manifesto.html>Deutsch</a><br>
+<a href=/iso/dk/manifesto.html>Dansk</a><br>
+<a href=/iso/el/manifesto.html>Ελληνικά</a><br>
+<a href=/>English</a><br>
+<a href=/iso/es/manifesto.html>Español</a><br>
+<a href=/iso/et/manifesto.html>Eesti</a><br>
+<a href=/iso/eu/manifesto.html>Euskara</a><br>
+<a href=/iso/fi/manifesto.html>Suomi</a><br>
+<a href=/iso/fr/manifesto.html>Français</a><br>
+<a href=/iso/ga/manifesto.html>Gaeilge</a><br>
+<a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
+<a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/he/manifesto.html>עברית</a><br>
+<a href=/iso/hi/manifesto.html>हिंदी</a><br>
+<a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
+<a href=/iso/hu/manifesto.html>Hungarian/Magyar</a><br>
+<a href=/iso/id/manifesto.html>Bahasa Indonesia</a><br>
+<a href=/iso/is/manifesto.html>Íslenska</a><br>
+<a href=/iso/it/manifesto.html>Italiano</a><br>
+<a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
+<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/ko/manifesto.html>한국어</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
+<a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
+<a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
+<a href=/iso/ne/manifesto.html>नेपाली</a><br>
+<a href=/iso/nl/manifesto.html>Nederlands</a><br>
+<a href=/iso/no/manifesto.html>Norsk</a><br>
+<a href=/iso/or/manifesto.html>ଓଡ଼ିଆ</a><br>
+<a href=/iso/pa/manifesto.html>ਪੰਜਾਬੀ</a><br>
+<a href=/iso/pl/manifesto.html>Polski</a><br>
+<a href=/iso/pr/manifesto.html>فارسی</a><br>
+<a href=/iso/ptbr/manifesto.html>Português Brasileiro</a><br>
+<a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
+<a href=/iso/ro/manifesto.html>Română</a><br>
+<a href=/iso/ru/manifesto.html>Русский</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sr/manifesto.html>Srpski</a><br>
+<a href=/iso/sv/manifesto.html>Svenska</a><br>
+<a href=/iso/sw/manifesto.html>Swahili</a><br>
+<a href=/iso/ta/manifesto.html>தமிழ்</a><br>
+<a href=/iso/te/manifesto.html>తెలుగు</a><br>
+<a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
+<a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
+<a href=/iso/tr/manifesto.html>Türkçe</a><br>
+<a href=/iso/ts/manifesto.html>Xitsonga</a><br>
+<a href=/iso/uk/manifesto.html>Українська</a><br>
+<a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
+<a href=/iso/yo/manifesto.html>Yoruba</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -88,4 +156,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/kk/manifesto.html
+++ b/iso/kk/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html>Agile бағдарламалық қамсыздандырудың он екі қағидасы</a><br><br><a href=/sign/signup.cgi>Become a Signatory</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
+Agile бағдарламалық қамсыздандырудың он екі қағидасы<br><br><a href=/sign/signup.cgi>Become a Signatory</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
 </font>
 <br><br>
 

--- a/iso/kk/manifesto.html
+++ b/iso/kk/manifesto.html
@@ -76,7 +76,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/kk/manifesto.html
+++ b/iso/kk/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-Agile бағдарламалық қамсыздандырудың он екі қағидасы<br><br><a href=/sign/signup.cgi>Become a Signatory</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
+Agile бағдарламалық қамсыздандырудың он екі қағидасы<br><br><a href=/display/index.html>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br>
 </font>
 <br><br>
 
@@ -101,7 +101,7 @@ Agile бағдарламалық қамсыздандырудың он екі қ
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/kk/manifesto.html
+++ b/iso/kk/manifesto.html
@@ -71,11 +71,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -90,6 +91,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -98,12 +100,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -118,11 +119,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -137,8 +137,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/km/manifesto.html
+++ b/iso/km/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/km/manifesto.html
+++ b/iso/km/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/km/manifesto.html
+++ b/iso/km/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/km/manifesto.html
+++ b/iso/km/manifesto.html
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/km/manifesto.html
+++ b/iso/km/manifesto.html
@@ -87,7 +87,7 @@ but only in its entirety through this notice.
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html>គោលការណ៍ទាំងដប់ពីររបស់កម្មវិធី Agile</a><br><br>
+គោលការណ៍ទាំងដប់ពីររបស់កម្មវិធី Agil<br><br>
 <a href=/display/index.html>មើលហត្ថលេខី</a><br><br>
 <a href=/authors.html>អំពីអ្នកនិពន្ធ</a><br>
 <a href=/history.html>About the Manifesto</a><br>

--- a/iso/ko/manifesto.html
+++ b/iso/ko/manifesto.html
@@ -129,7 +129,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ko/manifesto.html
+++ b/iso/ko/manifesto.html
@@ -99,11 +99,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ko/manifesto.html
+++ b/iso/ko/manifesto.html
@@ -104,7 +104,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ko/manifesto.html
+++ b/iso/ko/manifesto.html
@@ -44,7 +44,7 @@ best practices
 <p>
 <font size="+2">
 가치 있게 여긴다. 이 말은, 왼쪽에 있는 것들도 가치가 있지만,<br>
-우리는 오른쪽에 있는 것들에 더 높은 가치를 둔다는 것이다.<br> 
+우리는 오른쪽에 있는 것들에 더 높은 가치를 둔다는 것이다.<br>
 
 </font>
 <br><br><br><br>
@@ -99,19 +99,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/lt/manifesto.html
+++ b/iso/lt/manifesto.html
@@ -103,7 +103,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/lt/manifesto.html
+++ b/iso/lt/manifesto.html
@@ -128,7 +128,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/lt/manifesto.html
+++ b/iso/lt/manifesto.html
@@ -98,11 +98,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -117,6 +118,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -125,12 +127,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,11 +146,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -164,8 +164,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/lt/manifesto.html
+++ b/iso/lt/manifesto.html
@@ -98,19 +98,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -118,9 +116,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -129,10 +125,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -147,10 +145,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -158,14 +157,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -185,4 +185,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/lv/manifesto.html
+++ b/iso/lv/manifesto.html
@@ -170,7 +170,7 @@ but only in its entirety through this notice.
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-Latvian translation coordination by <a href=http://netrat.eu>Vladimir Tarasow</a>, with help from <a href="http://www.agile-latvia.org/">Agile Latvia</a>.
+Latvian translation coordination by Vladimir Tarasow, with help from Agile Latvia.
 
 </font>
 

--- a/iso/lv/manifesto.html
+++ b/iso/lv/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/lv/manifesto.html
+++ b/iso/lv/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/lv/manifesto.html
+++ b/iso/lv/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/lv/manifesto.html
+++ b/iso/lv/manifesto.html
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -184,4 +184,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/mk/manifesto.html
+++ b/iso/mk/manifesto.html
@@ -102,19 +102,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -122,9 +120,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -133,10 +129,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -151,10 +149,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -162,14 +161,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -192,4 +192,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/mk/manifesto.html
+++ b/iso/mk/manifesto.html
@@ -102,11 +102,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -121,6 +122,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -129,12 +131,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -149,11 +150,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -168,8 +168,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/mk/manifesto.html
+++ b/iso/mk/manifesto.html
@@ -107,7 +107,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/mk/manifesto.html
+++ b/iso/mk/manifesto.html
@@ -132,7 +132,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ms/manifesto.html
+++ b/iso/ms/manifesto.html
@@ -101,11 +101,12 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -120,6 +121,7 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,12 +130,11 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,11 +149,10 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -167,8 +167,8 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ms/manifesto.html
+++ b/iso/ms/manifesto.html
@@ -131,7 +131,7 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ms/manifesto.html
+++ b/iso/ms/manifesto.html
@@ -106,7 +106,7 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ms/manifesto.html
+++ b/iso/ms/manifesto.html
@@ -5,9 +5,9 @@
 <title>Manifesto untuk Pembangunan Perisian Agile
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="Kami sedang memperkenalkan cara yang lebih baik untuk 
-membangunkan perisian dengan cara melakukannya dan 
-membantu orang lain melakukannya. Ini adalah nilai-nilai 
+<META name="description" content="Kami sedang memperkenalkan cara yang lebih baik untuk
+membangunkan perisian dengan cara melakukannya dan
+membantu orang lain melakukannya. Ini adalah nilai-nilai
 dan prinsip-prinsip kami.
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
@@ -101,19 +101,17 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -121,9 +119,7 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -132,10 +128,12 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -150,10 +148,11 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -161,14 +160,15 @@ tetapi hanya secara keseluruhannya melalui notis ini.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -187,4 +187,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/my/manifesto.html
+++ b/iso/my/manifesto.html
@@ -112,7 +112,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/my/manifesto.html
+++ b/iso/my/manifesto.html
@@ -137,7 +137,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/my/manifesto.html
+++ b/iso/my/manifesto.html
@@ -107,11 +107,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -126,6 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -134,12 +136,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -154,11 +155,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -173,8 +173,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/my/manifesto.html
+++ b/iso/my/manifesto.html
@@ -9,7 +9,7 @@
 ">
 <META name="keywords" content="အဂျိုင်း(လ်) ကြေညာစာတန်း,
 အဂျိုင်း(လ်) မဟာမိတ်, မဟာမိတ်, ကြေညာစာတန်း,
-အဂျိုင်း(လ်), ပရိုဂရမ် ရေးသားခြင်း, 
+အဂျိုင်း(လ်), ပရိုဂရမ် ရေးသားခြင်း,
 ပရိုဂရမ် ရေးဆွဲခြင်း, အဂျိုင်း(လ်) ဆော့(ဖ်)ဝဲ(ရ်) ဖန်တီးမှု,
 အဂျိုင်း(လ်) ဖန်တီးမှု, အစွန်းရောက် ပရိုဂရမ် ရေးသားခြင်း,
 အစွန်းရောက် ပရိုဂရမ် ရေးဆွဲခြင်း,
@@ -107,19 +107,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -127,9 +125,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -138,10 +134,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -156,10 +154,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -167,14 +166,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -194,4 +194,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ne/manifesto.html
+++ b/iso/ne/manifesto.html
@@ -124,7 +124,7 @@ but only in its entirety through this notice
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ne/manifesto.html
+++ b/iso/ne/manifesto.html
@@ -99,7 +99,7 @@ but only in its entirety through this notice
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ne/manifesto.html
+++ b/iso/ne/manifesto.html
@@ -94,19 +94,17 @@ but only in its entirety through this notice
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -114,9 +112,7 @@ but only in its entirety through this notice
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -125,10 +121,12 @@ but only in its entirety through this notice
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -143,10 +141,11 @@ but only in its entirety through this notice
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -154,14 +153,15 @@ but only in its entirety through this notice
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -181,4 +181,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ne/manifesto.html
+++ b/iso/ne/manifesto.html
@@ -94,11 +94,12 @@ but only in its entirety through this notice
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -113,6 +114,7 @@ but only in its entirety through this notice
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -121,12 +123,11 @@ but only in its entirety through this notice
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -141,11 +142,10 @@ but only in its entirety through this notice
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -160,8 +160,8 @@ but only in its entirety through this notice
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/nl/manifesto.html
+++ b/iso/nl/manifesto.html
@@ -127,7 +127,7 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/nl/manifesto.html
+++ b/iso/nl/manifesto.html
@@ -97,19 +97,17 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -184,4 +184,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/nl/manifesto.html
+++ b/iso/nl/manifesto.html
@@ -97,11 +97,12 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/nl/manifesto.html
+++ b/iso/nl/manifesto.html
@@ -102,7 +102,7 @@ Maar enkel in zijn geheel met verwijzing naar het origineel.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/no/manifesto.html
+++ b/iso/no/manifesto.html
@@ -96,19 +96,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -116,9 +114,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -127,10 +123,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,10 +143,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -156,14 +155,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/no/manifesto.html
+++ b/iso/no/manifesto.html
@@ -101,7 +101,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/no/manifesto.html
+++ b/iso/no/manifesto.html
@@ -96,11 +96,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -115,6 +116,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -123,12 +125,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -143,11 +144,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -162,8 +162,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/no/manifesto.html
+++ b/iso/no/manifesto.html
@@ -126,7 +126,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/or/manifesto.html
+++ b/iso/or/manifesto.html
@@ -129,7 +129,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/or/manifesto.html
+++ b/iso/or/manifesto.html
@@ -99,19 +99,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/or/manifesto.html
+++ b/iso/or/manifesto.html
@@ -99,11 +99,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/or/manifesto.html
+++ b/iso/or/manifesto.html
@@ -172,7 +172,7 @@ Dave Thomas<br>
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-Odia translation by <a href="http://www.kaniska.in">Kan!skA</a>.
+Odia translation by <a href="https://www.kaniska.in">Kan!skA</a>.
 
 </font>
 

--- a/iso/or/manifesto.html
+++ b/iso/or/manifesto.html
@@ -104,7 +104,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/pa/manifesto.html
+++ b/iso/pa/manifesto.html
@@ -97,19 +97,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -184,4 +184,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/pa/manifesto.html
+++ b/iso/pa/manifesto.html
@@ -97,11 +97,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/pa/manifesto.html
+++ b/iso/pa/manifesto.html
@@ -102,7 +102,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/pa/manifesto.html
+++ b/iso/pa/manifesto.html
@@ -127,7 +127,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/pl/manifesto.html
+++ b/iso/pl/manifesto.html
@@ -99,11 +99,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/pl/manifesto.html
+++ b/iso/pl/manifesto.html
@@ -129,7 +129,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/pl/manifesto.html
+++ b/iso/pl/manifesto.html
@@ -5,8 +5,8 @@
 <title>Manifest programowania zwinnego
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="Wytwarzając oprogramowanie i pomagając innym w tym zakresie, 
-odkrywamy lepsze sposoby wykonywania tej pracy. 
+<META name="description" content="Wytwarzając oprogramowanie i pomagając innym w tym zakresie,
+odkrywamy lepsze sposoby wykonywania tej pracy.
 Oto są nasze wartości i zasady.
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
@@ -43,7 +43,7 @@ W wyniku naszej pracy, zaczęliśmy bardziej cenić:<br/>
 
 <p>
 <font size="+2">
-Oznacza to, że elementy wypisane po prawej są wartościowe,<br/> 
+Oznacza to, że elementy wypisane po prawej są wartościowe,<br/>
 ale większą wartość mają dla nas te, które wypisano po lewej.<br/>
 
 </font>
@@ -99,19 +99,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/pl/manifesto.html
+++ b/iso/pl/manifesto.html
@@ -104,7 +104,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/pr/manifesto.html
+++ b/iso/pr/manifesto.html
@@ -95,19 +95,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -115,9 +113,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,10 +122,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,10 +142,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -155,14 +154,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -182,4 +182,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/pr/manifesto.html
+++ b/iso/pr/manifesto.html
@@ -95,11 +95,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -114,6 +115,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -122,12 +124,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -142,11 +143,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -161,8 +161,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/pr/manifesto.html
+++ b/iso/pr/manifesto.html
@@ -100,7 +100,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/pr/manifesto.html
+++ b/iso/pr/manifesto.html
@@ -125,7 +125,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ptbr/manifesto.html
+++ b/iso/ptbr/manifesto.html
@@ -99,11 +99,12 @@ mas somente integralmente através desta declaração.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ mas somente integralmente através desta declaração.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ mas somente integralmente através desta declaração.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ mas somente integralmente através desta declaração.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ mas somente integralmente através desta declaração.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ptbr/manifesto.html
+++ b/iso/ptbr/manifesto.html
@@ -5,7 +5,7 @@
 <title>Manifesto para Desenvolvimento Ágil de Software
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="Estamos descobrindo maneiras melhores de desenvolver 
+<META name="description" content="Estamos descobrindo maneiras melhores de desenvolver
 software, fazendo-o nós mesmos e ajudando outros a
 fazerem. Estes são nossos valores e princípios.
 ">
@@ -13,7 +13,7 @@ fazerem. Estes são nossos valores e princípios.
 programacao agil, desenvolvimento agil,
 extreme programming, XP, gestao de projetos de software,
 desenvolvimento iterativo, desenvolvimento colaborativo,
-melhores prativcas de engenharia de software, 
+melhores prativcas de engenharia de software,
 desenvolvimento de software, melhores praticas
 ">
 </head>
@@ -99,19 +99,17 @@ mas somente integralmente através desta declaração.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ mas somente integralmente através desta declaração.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ mas somente integralmente através desta declaração.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ mas somente integralmente através desta declaração.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,20 +158,21 @@ mas somente integralmente através desta declaração.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
 <font size=1 color=gray>
 design do site e rabalho de cópia & arte; 2001, Ward Cunningham<br>
-tradução para o português brasileiro por Renato Willi, José Peleteiro, Heitor Roriz, Flávio Steffens de Castro, Luiz Cláudio Parzianello, Rafael Prikladnicki, Mariana Bravo, Dairton Bassi, Rafael Sabbagh Armony, André Faria Gomes, Cecília Fernandes, Rodrigo Toledo, Manoel Pimentel, Guilherme Silveira, Wescley Costa, Marcelo Andrade, Christian Peixoto, Hugo Corbucci 
+tradução para o português brasileiro por Renato Willi, José Peleteiro, Heitor Roriz, Flávio Steffens de Castro, Luiz Cláudio Parzianello, Rafael Prikladnicki, Mariana Bravo, Dairton Bassi, Rafael Sabbagh Armony, André Faria Gomes, Cecília Fernandes, Rodrigo Toledo, Manoel Pimentel, Guilherme Silveira, Wescley Costa, Marcelo Andrade, Christian Peixoto, Hugo Corbucci
 
 </font>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ptbr/manifesto.html
+++ b/iso/ptbr/manifesto.html
@@ -129,7 +129,7 @@ mas somente integralmente através desta declaração.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ptbr/manifesto.html
+++ b/iso/ptbr/manifesto.html
@@ -104,7 +104,7 @@ mas somente integralmente através desta declaração.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ptpt/manifesto.html
+++ b/iso/ptpt/manifesto.html
@@ -95,11 +95,12 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -114,6 +115,7 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -122,12 +124,11 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -142,11 +143,10 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -161,8 +161,8 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ptpt/manifesto.html
+++ b/iso/ptpt/manifesto.html
@@ -95,19 +95,17 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -115,9 +113,7 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,10 +122,12 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,10 +142,11 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -155,14 +154,15 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -182,4 +182,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ptpt/manifesto.html
+++ b/iso/ptpt/manifesto.html
@@ -100,7 +100,7 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ptpt/manifesto.html
+++ b/iso/ptpt/manifesto.html
@@ -125,7 +125,7 @@ Esta declaração pode ser copiada e distribuída livremente, e de qualquer form
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ro/manifesto.html
+++ b/iso/ro/manifesto.html
@@ -122,7 +122,7 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ro/manifesto.html
+++ b/iso/ro/manifesto.html
@@ -92,19 +92,17 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -112,9 +110,7 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -123,10 +119,12 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -141,10 +139,11 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -152,14 +151,15 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -180,4 +180,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ro/manifesto.html
+++ b/iso/ro/manifesto.html
@@ -92,11 +92,12 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -111,6 +112,7 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -119,12 +121,11 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -139,11 +140,10 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -158,8 +158,8 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ro/manifesto.html
+++ b/iso/ro/manifesto.html
@@ -97,7 +97,7 @@ prin această notă este permisă copierea liberă a acestei declaraţii<br>în 
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ru/manifesto.html
+++ b/iso/ru/manifesto.html
@@ -6,8 +6,8 @@
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="Мы постоянно открываем для себя более совершенные методы
-разработки программного обеспечения, занимаясь 
-разработкой непосредственно и помогая в этом другим. 
+разработки программного обеспечения, занимаясь
+разработкой непосредственно и помогая в этом другим.
 Вот наши ценности и принципы.
 ">
 <META name="keywords" content="Манифест Agile-разработки, Agile-альянc, манифест,
@@ -102,19 +102,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -122,9 +120,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -133,10 +129,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -151,10 +149,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -162,14 +161,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -190,4 +190,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ru/manifesto.html
+++ b/iso/ru/manifesto.html
@@ -102,11 +102,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -121,6 +122,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -129,12 +131,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -149,11 +150,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -168,8 +168,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ru/manifesto.html
+++ b/iso/ru/manifesto.html
@@ -107,7 +107,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ru/manifesto.html
+++ b/iso/ru/manifesto.html
@@ -132,7 +132,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/sa/manifesto.html
+++ b/iso/sa/manifesto.html
@@ -95,11 +95,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -114,6 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -122,12 +124,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -142,11 +143,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -161,8 +161,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/sa/manifesto.html
+++ b/iso/sa/manifesto.html
@@ -125,7 +125,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/sa/manifesto.html
+++ b/iso/sa/manifesto.html
@@ -2,7 +2,7 @@
 ">
 <html>
 <head>
-<title>विखेद तन्त्रम्श विकास प्रकटनम् 
+<title>विखेद तन्त्रम्श विकास प्रकटनम्
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="वयम् तन्त्रम्श केन्द्रे , स्वयम् च सर्वेशम् सहायम् कुर्वन् नुतन रुपेन तन्त्रम्श व्रिधि कुर्वन्तः स्म ! येवम् कुर्वन् वयम् यवम् मुल्यम् विज्ञातः
@@ -19,7 +19,7 @@ best practices
 <center>
 <br><br><br><br>
 
-<h1>विखेद तन्त्रम्श विकास प्रकटनम् 
+<h1>विखेद तन्त्रम्श विकास प्रकटनम्
 </h1>
 <br><br><br>
 
@@ -95,19 +95,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -115,9 +113,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,10 +122,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,10 +142,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -155,14 +154,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -181,4 +181,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/sa/manifesto.html
+++ b/iso/sa/manifesto.html
@@ -100,7 +100,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/si/manifesto.html
+++ b/iso/si/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/si/manifesto.html
+++ b/iso/si/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/si/manifesto.html
+++ b/iso/si/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/si/manifesto.html
+++ b/iso/si/manifesto.html
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -184,4 +184,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/sk/manifesto.html
+++ b/iso/sk/manifesto.html
@@ -95,11 +95,12 @@ ale iba vcelku.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -114,6 +115,7 @@ ale iba vcelku.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -122,12 +124,11 @@ ale iba vcelku.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -142,11 +143,10 @@ ale iba vcelku.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -161,8 +161,8 @@ ale iba vcelku.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/sk/manifesto.html
+++ b/iso/sk/manifesto.html
@@ -125,7 +125,7 @@ ale iba vcelku.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/sk/manifesto.html
+++ b/iso/sk/manifesto.html
@@ -5,7 +5,7 @@
 <title>Manifesto agilného vývoja softvéru
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="Odkrývame lepšie spôsoby vývoja softvéru jeho robením a pomáhaním iným ho robiť.<br> 
+<META name="description" content="Odkrývame lepšie spôsoby vývoja softvéru jeho robením a pomáhaním iným ho robiť.<br>
 Vďaka tejto práci sme identifikovali tieto hodnoty:
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
@@ -95,19 +95,17 @@ ale iba vcelku.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -115,9 +113,7 @@ ale iba vcelku.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,10 +122,12 @@ ale iba vcelku.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,10 +142,11 @@ ale iba vcelku.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -155,14 +154,15 @@ ale iba vcelku.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/sk/manifesto.html
+++ b/iso/sk/manifesto.html
@@ -100,7 +100,7 @@ ale iba vcelku.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/sl/manifesto.html
+++ b/iso/sl/manifesto.html
@@ -129,7 +129,7 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/sl/manifesto.html
+++ b/iso/sl/manifesto.html
@@ -99,11 +99,12 @@ vendar samo v celoti, s tem opozorilom vred.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/sl/manifesto.html
+++ b/iso/sl/manifesto.html
@@ -104,7 +104,7 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/sl/manifesto.html
+++ b/iso/sl/manifesto.html
@@ -5,15 +5,15 @@
 <title>Manifest agilnega razvoja programske opreme
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<META name="description" content="Odkrivamo boljše načine razvoja programske opreme, 
+<META name="description" content="Odkrivamo boljše načine razvoja programske opreme,
 tako, da jo razvijamo, in pri tem pomagamo tudi drugim.
 To so naše vrednote in principi.
 ">
-<META name="keywords" content="agilni manifest, agilna aliansa, manifesto alianse, 
-agilno programiranje, agilni razvoj, 
-ekstremno programiranje, XP, programsko projektno vodenje, 
-iterativni razvoj, kolaborativni razvoj, 
-dobre prakse programskega inženirstva, 
+<META name="keywords" content="agilni manifest, agilna aliansa, manifesto alianse,
+agilno programiranje, agilni razvoj,
+ekstremno programiranje, XP, programsko projektno vodenje,
+iterativni razvoj, kolaborativni razvoj,
+dobre prakse programskega inženirstva,
 razvoj programske opreme, dobre prakse
 ">
 </head>
@@ -99,19 +99,17 @@ vendar samo v celoti, s tem opozorilom vred.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ vendar samo v celoti, s tem opozorilom vred.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/sq/manifesto.html
+++ b/iso/sq/manifesto.html
@@ -104,7 +104,7 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/sq/manifesto.html
+++ b/iso/sq/manifesto.html
@@ -99,19 +99,17 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -186,4 +186,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/sq/manifesto.html
+++ b/iso/sq/manifesto.html
@@ -99,11 +99,12 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/sq/manifesto.html
+++ b/iso/sq/manifesto.html
@@ -172,7 +172,7 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham
-<br />Albanian translation from <a href=http://sites.google.com/site/kalabuli/>Ridvan Bunjaku</a>, with the help of Albanian Developers Community.
+<br />Albanian translation from <a href=https://sites.google.com/site/kalabuli/>Ridvan Bunjaku</a>, with the help of Albanian Developers Community.
 
 </font>
 

--- a/iso/sq/manifesto.html
+++ b/iso/sq/manifesto.html
@@ -129,7 +129,7 @@ por vetëm si e plotë përmes kësaj vërejtjeje.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/sr/manifesto.html
+++ b/iso/sr/manifesto.html
@@ -6,7 +6,7 @@
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="Otkrivamo bolje načine razvoja softvera
-razvijajući softver sami i pomažući drugima pri 
+razvijajući softver sami i pomažući drugima pri
 njegovom razvijanju. Ovo su naše vrednosti i principi.
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
@@ -15,10 +15,10 @@ extreme programming, XP, software project management,
 iterative development, collaborative development,
 software engineering best practices, software development,
 best practices
-agilnimanifest, agilnisavez, manifest saveza, 
+agilnimanifest, agilnisavez, manifest saveza,
 agilno programiranje, agilni razvoj, ekstremno
-programiranje, XP, upravljanje razvojem softvera, 
-razvoj kroz iteracije, kolaborativni razvoj, 
+programiranje, XP, upravljanje razvojem softvera,
+razvoj kroz iteracije, kolaborativni razvoj,
 razvoj softvera, agilne metode, agilni manifest
 ">
 </head>
@@ -90,7 +90,7 @@ Dave Thomas<br>
 
 <font size=1 color=gray>
 &copy; 2001, gore navedeni autori<br>
-ova deklaracija može biti slobodno umnožena u 
+ova deklaracija može biti slobodno umnožena u
 bilo kojoj formi, <br>
 ali samo u svom integralnom obliku putem ove objave
 
@@ -107,19 +107,17 @@ ali samo u svom integralnom obliku putem ove objave
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -127,9 +125,7 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -138,10 +134,12 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -156,10 +154,11 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -167,25 +166,26 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
 <font size=1 color=gray>
 Dizajn internet przentacije i umetničko rešenje &copy; 2001, Ward Cunningham <br>
-Srpski prevod:  
+Srpski prevod:
 <a href="http://www.empoweragile.com/en">Danijel
 Arsenovski</a>,
 <a href="http://www.denittisprevodi.co.rs">Dejan
-Arsenovski</a> i zajednica 
-<a href="http://www.agilni.rs">Agilni 
+Arsenovski</a> i zajednica
+<a href="http://www.agilni.rs">Agilni
 Srbija</a>
 
 </font>
@@ -200,4 +200,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/sr/manifesto.html
+++ b/iso/sr/manifesto.html
@@ -181,11 +181,11 @@ ali samo u svom integralnom obliku putem ove objave
 <font size=1 color=gray>
 Dizajn internet przentacije i umetničko rešenje &copy; 2001, Ward Cunningham <br>
 Srpski prevod:
-<a href="http://www.empoweragile.com/en">Danijel
+<a href="http://www.empoweragile.com/en/">Danijel
 Arsenovski</a>,
-<a href="http://www.denittisprevodi.co.rs">Dejan
-Arsenovski</a> i zajednica
-<a href="http://www.agilni.rs">Agilni
+Dejan
+Arsenovski i zajednica
+<a href="http://www.agilni.rs/">Agilni
 Srbija</a>
 
 </font>

--- a/iso/sr/manifesto.html
+++ b/iso/sr/manifesto.html
@@ -107,11 +107,12 @@ ali samo u svom integralnom obliku putem ove objave
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -126,6 +127,7 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -134,12 +136,11 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -154,11 +155,10 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -173,8 +173,8 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/sr/manifesto.html
+++ b/iso/sr/manifesto.html
@@ -137,7 +137,7 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/sr/manifesto.html
+++ b/iso/sr/manifesto.html
@@ -112,7 +112,7 @@ ali samo u svom integralnom obliku putem ove objave
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/sv/manifesto.html
+++ b/iso/sv/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/sv/manifesto.html
+++ b/iso/sv/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/sv/manifesto.html
+++ b/iso/sv/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/sv/manifesto.html
+++ b/iso/sv/manifesto.html
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -184,4 +184,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/sv/manifesto.html
+++ b/iso/sv/manifesto.html
@@ -170,7 +170,7 @@ but only in its entirety through this notice.
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-Swedish translation by <a href=http://www.crisp.se/henrik.kniberg>Henrik Kniberg</a>, with help from <a href="http://www.agilesweden.com/">Agile Sweden</a>.
+Swedish translation by <a href=https://www.crisp.se/konsulter/henrik-kniberg>Henrik Kniberg</a>, with help from <a href="http://www.agilesweden.com/">Agile Sweden</a>.
 
 </font>
 

--- a/iso/sw/manifesto.html
+++ b/iso/sw/manifesto.html
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -182,4 +182,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/sw/manifesto.html
+++ b/iso/sw/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/sw/manifesto.html
+++ b/iso/sw/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/sw/manifesto.html
+++ b/iso/sw/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ta/manifesto.html
+++ b/iso/ta/manifesto.html
@@ -96,19 +96,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -116,9 +114,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -127,10 +123,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,10 +143,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -156,14 +155,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ta/manifesto.html
+++ b/iso/ta/manifesto.html
@@ -101,7 +101,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ta/manifesto.html
+++ b/iso/ta/manifesto.html
@@ -96,11 +96,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -115,6 +116,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -123,12 +125,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -143,11 +144,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -162,8 +162,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ta/manifesto.html
+++ b/iso/ta/manifesto.html
@@ -126,7 +126,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/te/manifesto.html
+++ b/iso/te/manifesto.html
@@ -99,11 +99,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/te/manifesto.html
+++ b/iso/te/manifesto.html
@@ -129,7 +129,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/te/manifesto.html
+++ b/iso/te/manifesto.html
@@ -104,7 +104,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/te/manifesto.html
+++ b/iso/te/manifesto.html
@@ -99,19 +99,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,14 +158,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -185,4 +185,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/th/manifesto.html
+++ b/iso/th/manifesto.html
@@ -100,19 +100,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -120,9 +118,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -131,10 +127,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -149,10 +147,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -160,14 +159,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -187,4 +187,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/th/manifesto.html
+++ b/iso/th/manifesto.html
@@ -130,7 +130,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/th/manifesto.html
+++ b/iso/th/manifesto.html
@@ -105,7 +105,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/th/manifesto.html
+++ b/iso/th/manifesto.html
@@ -100,11 +100,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -119,6 +120,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -127,12 +129,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -147,11 +148,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -166,8 +166,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/th/manifesto.html
+++ b/iso/th/manifesto.html
@@ -173,7 +173,7 @@ but only in its entirety through this notice.
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-Thai translation by <a href="http://www.agile66.com">Agile66.com Community</a>
+Thai translation by Agile66.com Community
 
 </font>
 

--- a/iso/tl/manifesto.html
+++ b/iso/tl/manifesto.html
@@ -123,7 +123,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/tl/manifesto.html
+++ b/iso/tl/manifesto.html
@@ -93,19 +93,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -113,9 +111,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,10 +120,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -142,10 +140,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -153,14 +152,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -180,4 +180,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/tl/manifesto.html
+++ b/iso/tl/manifesto.html
@@ -98,7 +98,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/tl/manifesto.html
+++ b/iso/tl/manifesto.html
@@ -93,11 +93,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -112,6 +113,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -120,12 +122,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -140,11 +141,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,8 +159,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/tm/manifesto.html
+++ b/iso/tm/manifesto.html
@@ -76,7 +76,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/tm/manifesto.html
+++ b/iso/tm/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html>துரித மென்பொருளுக்கான பன்னிரெண்டு கொள்கைகள்</a><br><br><a href=/sign/signup.cgi>Become a Signatory</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
+<a href=principles.html>துரித மென்பொருளுக்கான பன்னிரெண்டு கொள்கைகள்</a><br<a href=/display/index.html>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a>
 </font>
 <br><br>
 
@@ -101,7 +101,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/tm/manifesto.html
+++ b/iso/tm/manifesto.html
@@ -71,11 +71,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -90,6 +91,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -98,12 +100,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -118,11 +119,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -137,8 +137,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/tm/manifesto.html
+++ b/iso/tm/manifesto.html
@@ -70,7 +70,75 @@ Dave Thomas<br>
 <br><br>
 
 <font size="+2">
-<a href=/iso/af>Afrikaans</a><br><a href=/iso/sq>Albanian</a><br><a href=/iso/ar>عربي</a><br><a href=/iso/az>Azərbaycanca</a><br><a href=/iso/be>Беларуская</a><br><a href=/iso/bs>Bosanski</a><br><a href=/iso/bg>Български</a><br><a href=/iso/ca>Català</a><br><a href=/iso/cs>Česky</a><br><a href=/iso/de>Deutsch</a><br><a href=/iso/dk>Dansk</a><br><a href=/iso/el>Ελληνικά</a><br><a href=/iso/en>English</a><br><a href=/iso/es>Español</a><br><a href=/iso/et>Eesti</a><br><a href=/iso/eu>Euskara</a><br><a href=/iso/fi>Suomi</a><br><a href=/iso/fr>Français</a><br><a href=/iso/ga>Gaeilge</a><br><a href=/iso/gd>Gàidhlig</a><br><a href=/iso/ka>ქართული</a><br><a href=/iso/he>עברית</a><br><a href=/iso/hi>हिंदी</a><br><a href=/iso/hr>Croatian/Hrvatski</a><br><a href=/iso/hu>Hungarian/Magyar</a><br><a href=/iso/id>Bahasa Indonesia</a><br><a href=/iso/is>Íslenska</a><br><a href=/iso/it>Italiano</a><br><a href=/iso/ja>日本語</a><br><a href=/iso/ko>한국어</a><br><a href=/iso/lv>Latviešu</a><br><a href=/iso/lt>Lietuvių</a><br><a href=/iso/mk>Македонски/Macedonian</a><br><a href=/iso/ms>Bahasa Melayu</a><br><a href=/iso/nl>Nederlands</a><br><a href=/iso/nl>नेपाली</a><br><a href=/iso/no>Norsk</a><br><a href=/iso/pl>Polski</a><br><a href=/iso/pr>فارسی</a><br><a href=/iso/ptbr>Português Brasileiro</a><br><a href=/iso/ptpt>Português Portugal</a><br><a href=/iso/ro>Română</a><br><a href=/iso/ru>Русский</a><br><a href=/iso/sl>Slovenščina</a><br><a href=/iso/sk>Slovensky</a><br><a href=/iso/sa>संस्कृत</a><br><a href=/iso/sr>Srpski</a><br><a href=/iso/sv>Svenska</a><br><a href=/iso/tm>தமிழ்</a><br><a href=/iso/te>తెలుగు</a><br><a href=/iso/th>ภาษาไทย</a><br><a href=/iso/tl>Filipino</a><br><a href=/iso/tr>Türkçe</a><br><a href=/iso/ts>Xitsonga</a><br><a href=/iso/uk>Українська</a><br><a href=/iso/ur>اردو</a><br><a href=/iso/yo>Yoruba</a><br><a href=/iso/zhcht>繁體中文</a><br><a href=/iso/zhchs>简体中文</a><br>
+<a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/ar/manifesto.html>عربي</a><br>
+<a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
+<a href=/iso/be/manifesto.html>Беларуская</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/ca/manifesto.html>Català</a><br>
+<a href=/iso/cs/manifesto.html>Česky</a><br>
+<a href=/iso/de/manifesto.html>Deutsch</a><br>
+<a href=/iso/dk/manifesto.html>Dansk</a><br>
+<a href=/iso/el/manifesto.html>Ελληνικά</a><br>
+<a href=/>English</a><br>
+<a href=/iso/es/manifesto.html>Español</a><br>
+<a href=/iso/et/manifesto.html>Eesti</a><br>
+<a href=/iso/eu/manifesto.html>Euskara</a><br>
+<a href=/iso/fi/manifesto.html>Suomi</a><br>
+<a href=/iso/fr/manifesto.html>Français</a><br>
+<a href=/iso/ga/manifesto.html>Gaeilge</a><br>
+<a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
+<a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/he/manifesto.html>עברית</a><br>
+<a href=/iso/hi/manifesto.html>हिंदी</a><br>
+<a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
+<a href=/iso/hu/manifesto.html>Hungarian/Magyar</a><br>
+<a href=/iso/id/manifesto.html>Bahasa Indonesia</a><br>
+<a href=/iso/is/manifesto.html>Íslenska</a><br>
+<a href=/iso/it/manifesto.html>Italiano</a><br>
+<a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
+<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/ko/manifesto.html>한국어</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
+<a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
+<a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
+<a href=/iso/ne/manifesto.html>नेपाली</a><br>
+<a href=/iso/nl/manifesto.html>Nederlands</a><br>
+<a href=/iso/no/manifesto.html>Norsk</a><br>
+<a href=/iso/or/manifesto.html>ଓଡ଼ିଆ</a><br>
+<a href=/iso/pa/manifesto.html>ਪੰਜਾਬੀ</a><br>
+<a href=/iso/pl/manifesto.html>Polski</a><br>
+<a href=/iso/pr/manifesto.html>فارسی</a><br>
+<a href=/iso/ptbr/manifesto.html>Português Brasileiro</a><br>
+<a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
+<a href=/iso/ro/manifesto.html>Română</a><br>
+<a href=/iso/ru/manifesto.html>Русский</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sr/manifesto.html>Srpski</a><br>
+<a href=/iso/sv/manifesto.html>Svenska</a><br>
+<a href=/iso/sw/manifesto.html>Swahili</a><br>
+<a href=/iso/ta/manifesto.html>தமிழ்</a><br>
+<a href=/iso/te/manifesto.html>తెలుగు</a><br>
+<a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
+<a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
+<a href=/iso/tr/manifesto.html>Türkçe</a><br>
+<a href=/iso/ts/manifesto.html>Xitsonga</a><br>
+<a href=/iso/uk/manifesto.html>Українська</a><br>
+<a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
+<a href=/iso/yo/manifesto.html>Yoruba</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -88,4 +156,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/tr/manifesto.html
+++ b/iso/tr/manifesto.html
@@ -7,7 +7,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="Bizler daha iyi yazılım geliştirme yollarını, uygulayarak  ve başkalarının da uygulamasına yardım ederek, ortaya çıkartıyoruz. Buradakiler bizim değer ve prensiplerimizdir.
 ">
-<META name="keywords" content="çevik bildiri, çevik yazılım, çevik programlama, 
+<META name="keywords" content="çevik bildiri, çevik yazılım, çevik programlama,
 yazılım  proje yönetimi, agilemanifesto agilealliance  , yinelemeli geliştirme, alliance manifesto, agile programming,  agile development, işbirlikçi geliştirme, yazılım geliştirmenin en iyi yöntemleri,
 extreme programming, XP, software project management,
 iterative development, collaborative development,
@@ -96,19 +96,17 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -116,9 +114,7 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -127,10 +123,12 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,10 +143,11 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -156,14 +155,15 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/tr/manifesto.html
+++ b/iso/tr/manifesto.html
@@ -126,7 +126,7 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/tr/manifesto.html
+++ b/iso/tr/manifesto.html
@@ -96,11 +96,12 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -115,6 +116,7 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -123,12 +125,11 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -143,11 +144,10 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -162,8 +162,8 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/tr/manifesto.html
+++ b/iso/tr/manifesto.html
@@ -101,7 +101,7 @@ bu bildiri bu bölüme kadar bütün korunduğu takdirde istenildiği şekilde d
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ts/manifesto.html
+++ b/iso/ts/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ts/manifesto.html
+++ b/iso/ts/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ts/manifesto.html
+++ b/iso/ts/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ts/manifesto.html
+++ b/iso/ts/manifesto.html
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -184,4 +184,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ua/manifesto.html
+++ b/iso/ua/manifesto.html
@@ -70,7 +70,75 @@ Dave Thomas<br>
 <br><br>
 
 <font size="+2">
-<a href=/iso/ar>عربي</a><br><a href=/iso/be>Беларуская</a><br><a href=/iso/bg>Български</a><br><a href=/iso/ca>Català</a><br><a href=/iso/de>Deutsch</a><br><a href=/iso/en>English</a><br><a href=/iso/es>Español</a><br><a href=/iso/fr>Français</a><br><a href=/iso/he>עברית</a><br><a href=/iso/it>Italiano</a><br><a href=/iso/ja>日本語</a><br><a href=/iso/nl>Nederlands</a><br><a href=/iso/no>Norsk</a><br><a href=/iso/pl>Polski</a><br><a href=/iso/pr>فارسی</a><br><a href=/iso/ptbr>Português Brasileiro</a><br><a href=/iso/ptpt>Português Portugal</a><br><a href=/iso/ru>Русский</a><br><a href=/iso/sr>Srpski</a><br><a href=/iso/sv>Svenska</a><br><a href=/iso/ua>Українська</a><br><a href=/iso/zhcht>繁體中文</a><br>
+<a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/ar/manifesto.html>عربي</a><br>
+<a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
+<a href=/iso/be/manifesto.html>Беларуская</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/ca/manifesto.html>Català</a><br>
+<a href=/iso/cs/manifesto.html>Česky</a><br>
+<a href=/iso/de/manifesto.html>Deutsch</a><br>
+<a href=/iso/dk/manifesto.html>Dansk</a><br>
+<a href=/iso/el/manifesto.html>Ελληνικά</a><br>
+<a href=/>English</a><br>
+<a href=/iso/es/manifesto.html>Español</a><br>
+<a href=/iso/et/manifesto.html>Eesti</a><br>
+<a href=/iso/eu/manifesto.html>Euskara</a><br>
+<a href=/iso/fi/manifesto.html>Suomi</a><br>
+<a href=/iso/fr/manifesto.html>Français</a><br>
+<a href=/iso/ga/manifesto.html>Gaeilge</a><br>
+<a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
+<a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/he/manifesto.html>עברית</a><br>
+<a href=/iso/hi/manifesto.html>हिंदी</a><br>
+<a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
+<a href=/iso/hu/manifesto.html>Hungarian/Magyar</a><br>
+<a href=/iso/id/manifesto.html>Bahasa Indonesia</a><br>
+<a href=/iso/is/manifesto.html>Íslenska</a><br>
+<a href=/iso/it/manifesto.html>Italiano</a><br>
+<a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
+<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/ko/manifesto.html>한국어</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
+<a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
+<a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
+<a href=/iso/ne/manifesto.html>नेपाली</a><br>
+<a href=/iso/nl/manifesto.html>Nederlands</a><br>
+<a href=/iso/no/manifesto.html>Norsk</a><br>
+<a href=/iso/or/manifesto.html>ଓଡ଼ିଆ</a><br>
+<a href=/iso/pa/manifesto.html>ਪੰਜਾਬੀ</a><br>
+<a href=/iso/pl/manifesto.html>Polski</a><br>
+<a href=/iso/pr/manifesto.html>فارسی</a><br>
+<a href=/iso/ptbr/manifesto.html>Português Brasileiro</a><br>
+<a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
+<a href=/iso/ro/manifesto.html>Română</a><br>
+<a href=/iso/ru/manifesto.html>Русский</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sr/manifesto.html>Srpski</a><br>
+<a href=/iso/sv/manifesto.html>Svenska</a><br>
+<a href=/iso/sw/manifesto.html>Swahili</a><br>
+<a href=/iso/ta/manifesto.html>தமிழ்</a><br>
+<a href=/iso/te/manifesto.html>తెలుగు</a><br>
+<a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
+<a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
+<a href=/iso/tr/manifesto.html>Türkçe</a><br>
+<a href=/iso/ts/manifesto.html>Xitsonga</a><br>
+<a href=/iso/uk/manifesto.html>Українська</a><br>
+<a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
+<a href=/iso/yo/manifesto.html>Yoruba</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -88,4 +156,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ua/manifesto.html
+++ b/iso/ua/manifesto.html
@@ -76,7 +76,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ua/manifesto.html
+++ b/iso/ua/manifesto.html
@@ -101,7 +101,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ua/manifesto.html
+++ b/iso/ua/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html>Дванадцять принципів Agile-розробки</a><br><br><a href=/sign/signup.cgi>Підписати маніфест</a><br><a href=/sign/display.cgi>Переглянути підписантів</a><br><br><a href=/authors.html>Про авторів</a><br><a href=/history.html>Про маніфест</a><br><a href="http://www.agilealliance.org/show/2548">Допоможіть нам перекласти маніфест</a>
+<a href=principles.html>Дванадцять принципів Agile-розробки</a><br><br><a href=/display/index.html>Переглянути підписантів</a><br><br><a href=/authors.html>Про авторів</a><br><a href=/history.html>Про маніфест</a><br>
 </font>
 <br><br>
 

--- a/iso/ua/manifesto.html
+++ b/iso/ua/manifesto.html
@@ -71,11 +71,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -90,6 +91,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -98,12 +100,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -118,11 +119,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -137,8 +137,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/uk/manifesto.html
+++ b/iso/uk/manifesto.html
@@ -129,7 +129,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/uk/manifesto.html
+++ b/iso/uk/manifesto.html
@@ -99,11 +99,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -118,6 +119,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -126,12 +128,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,11 +147,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -165,8 +165,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/uk/manifesto.html
+++ b/iso/uk/manifesto.html
@@ -6,8 +6,8 @@
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="Ми постійно відкриваємо для себе досконаліші методи
-розробки програмного забезпечення, займаючись розробкою 
-безпосередньо та допомагаючи у цьому іншим. Ось нашi 
+розробки програмного забезпечення, займаючись розробкою
+безпосередньо та допомагаючи у цьому іншим. Ось нашi
 цінності та принципи.
 ">
 <META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
@@ -99,19 +99,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -119,9 +117,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -130,10 +126,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -148,10 +146,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -159,21 +158,22 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
 <font size=1 color=gray>
 дизайн та оформлення сайту &copy; 2001, Ward Cunningham <br>
 Переклад українською мовою виконали Олексій Солнцев,
-Сергій Мовчан, Андрій Мудрий, Сергій Євтушенко, 
+Сергій Мовчан, Андрій Мудрий, Сергій Євтушенко,
 Ліна Шишкіна та Тім Євграшин
 
 </font>
@@ -188,4 +188,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/uk/manifesto.html
+++ b/iso/uk/manifesto.html
@@ -104,7 +104,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ur/manifesto.html
+++ b/iso/ur/manifesto.html
@@ -2,7 +2,7 @@
 ">
 <html>
 <head>
-<title>ایجا ئل سافٹ ویئر کا منشور 
+<title>ایجا ئل سافٹ ویئر کا منشور
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <META name="description" content="ہم  خود سے اور دوسروں کی مدد کرنے سے سافٹ ویئر بنانے کے بہتر طریقے وضح کر رہے ہیں۔ یہ ہماری اقدار اور اصول ہیں۔
@@ -19,7 +19,7 @@ best practices
 <center>
 <br><br><br><br>
 
-<h1>ایجا ئل سافٹ ویئر کا منشور 
+<h1>ایجا ئل سافٹ ویئر کا منشور
 </h1>
 <br><br><br>
 
@@ -97,19 +97,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -117,9 +115,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -128,10 +124,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -146,10 +144,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -157,14 +156,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -185,4 +185,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/ur/manifesto.html
+++ b/iso/ur/manifesto.html
@@ -127,7 +127,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/ur/manifesto.html
+++ b/iso/ur/manifesto.html
@@ -102,7 +102,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/ur/manifesto.html
+++ b/iso/ur/manifesto.html
@@ -97,11 +97,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -116,6 +117,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -124,12 +126,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -144,11 +145,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -163,8 +163,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/ur/manifesto.html
+++ b/iso/ur/manifesto.html
@@ -170,7 +170,7 @@ but only in its entirety through this notice.
 
 <font size=1 color=gray>
 site design and artwork &copy; 2001, Ward Cunningham<br>
-Urdu translation by: <a href="http://www.mashalsoftware.com">Assad Baig</a>, M. Shafiq and Muhammad Saleem Khalid.<br>
+Urdu translation by: Assad Baig, M. Shafiq and Muhammad Saleem Khalid.<br>
 Special thanks to: Muhammad Faisal Mirza and Muhammad Ilyas.
 
 </font>

--- a/iso/vi/manifesto.html
+++ b/iso/vi/manifesto.html
@@ -103,7 +103,7 @@ với điều kiện phải sao chép toàn bộ văn bản bao gồm cả phầ
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/vi/manifesto.html
+++ b/iso/vi/manifesto.html
@@ -98,11 +98,12 @@ với điều kiện phải sao chép toàn bộ văn bản bao gồm cả phầ
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -117,6 +118,7 @@ với điều kiện phải sao chép toàn bộ văn bản bao gồm cả phầ
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -125,12 +127,11 @@ với điều kiện phải sao chép toàn bộ văn bản bao gồm cả phầ
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,11 +146,10 @@ với điều kiện phải sao chép toàn bộ văn bản bao gồm cả phầ
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -164,8 +164,8 @@ với điều kiện phải sao chép toàn bộ văn bản bao gồm cả phầ
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/vi/manifesto.html
+++ b/iso/vi/manifesto.html
@@ -16,7 +16,7 @@ software engineering best practices, software development,
 best practices
 ">
 </head>
-<body background="./background.jpg">
+<body background="/background.jpg">
 <center>
 <br><br><br><br>
 
@@ -88,7 +88,7 @@ với điều kiện phải sao chép toàn bộ văn bản bao gồm cả phầ
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html">12 qui tắc của phát triển phần mềm Agile</a><br><br>
+<a href=principles.html>12 qui tắc của phát triển phần mềm Agile</a><br><br>
 <a href=/display/index.html>View Signatories</a><br><br>
 <a href=/authors.html>About the Authors</a><br>
 <a href=/history.html>About the Manifesto</a><br>

--- a/iso/vi/manifesto.html
+++ b/iso/vi/manifesto.html
@@ -128,7 +128,7 @@ với điều kiện phải sao chép toàn bộ văn bản bao gồm cả phầ
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/vi/manifesto.html
+++ b/iso/vi/manifesto.html
@@ -1,0 +1,187 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//VI">
+<html>
+<head>
+<title>Tuyên ngôn phát triển phần mền Agile
+</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="description" content="Chúng tôi đã phát hiện ra cách phát triển phần mềm tốt hơn
+bằng cách thực hiện nó và giúp đỡ những người khác thực hiện.
+Sau đây là các giá trị và nguyên tắc chúng tôi đã rút ra được.
+">
+<META name="keywords" content="agilemanifesto agilealliance alliance manifesto,
+agile programming, agile development,
+extreme programming, XP, software project management,
+iterative development, collaborative development,
+software engineering best practices, software development,
+best practices
+">
+</head>
+<body background="./background.jpg">
+<center>
+<br><br><br><br>
+
+<h1>Tuyên ngôn phát triển phần mềm Agile
+</h1>
+<br><br><br>
+
+<p>
+
+<font size="+2">
+Chúng tôi đã phát hiện ra cách phát triển phần mềm tốt hơn<br>
+bằng cách thực hiện nó và giúp đỡ những người khác thực hiện.<br>
+Qua công việc này, chúng tôi đã đi đến việc đánh giá cao<br>
+
+</font>
+
+<p>
+<font size="+2"></font><font size="+3">Cá nhân và sự tương tác </font><font size="+2">hơn là qui trình và công cụ<br></font>
+<font size="+2"></font><font size="+3">Phần mềm chạy tốt </font><font size="+2">hơn là tài liệu đầy đủ<br></font>
+<font size="+2"></font><font size="+3">Cộng tác với khách hàng </font><font size="+2">hơn là đàm phán hợp đồng<br></font>
+<font size="+2"></font><font size="+3">Phản hồi với sự thay đổi </font><font size="+2">hơn là bám theo kế hoạch<br></font>
+
+
+<p>
+<font size="+2">
+Mặc dù các điều bên phải vẫn còn giá trị,<br>
+Nhưng chúng tôi đánh giá cao hơn các mục ở bên trái<br>
+
+</font>
+<br><br><br><br>
+
+<table cellpadding=15><tr align=center valign=top>
+<td><font size="+2">
+<td><font size="+2">
+Kent Beck<br>
+Mike Beedle<br>
+Arie van Bennekum<br>
+Alistair Cockburn<br>
+Ward Cunningham<br>
+Martin Fowler<br>
+</font></td>
+
+<td><font size="+2">
+
+James Grenning<br>
+Jim Highsmith<br>
+Andrew Hunt<br>
+Ron Jeffries<br>
+Jon Kern<br>
+Brian Marick<br>
+</font></td>
+
+<td><font size="+2">
+Robert C. Martin<br>
+
+Steve Mellor<br>
+Ken Schwaber<br>
+Jeff Sutherland<br>
+Dave Thomas<br>
+</font></td>
+</tr></table>
+<br><br><br>
+
+<font size=1 color=gray>
+© 2001, Trên đây là các tác giả<br>
+Bạn có thể tự do sao chép tuyên ngôn này dưới bất kỳ hình thức nào,<br>
+với điều kiện phải sao chép toàn bộ văn bản bao gồm cả phần lưu ý này.<br>
+
+</font>
+<br><br>
+<font size="+2">
+<a href=principles.html">12 qui tắc của phát triển phần mềm Agile</a><br><br>
+<a href=/display/index.html>View Signatories</a><br><br>
+<a href=/authors.html>About the Authors</a><br>
+<a href=/history.html>About the Manifesto</a><br>
+
+</font>
+<br><br>
+
+<font size="+2">
+<a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/ar/manifesto.html>عربي</a><br>
+<a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
+<a href=/iso/be/manifesto.html>Беларуская</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/ca/manifesto.html>Català</a><br>
+<a href=/iso/cs/manifesto.html>Česky</a><br>
+<a href=/iso/de/manifesto.html>Deutsch</a><br>
+<a href=/iso/dk/manifesto.html>Dansk</a><br>
+<a href=/iso/el/manifesto.html>Ελληνικά</a><br>
+<a href=/>English</a><br>
+<a href=/iso/es/manifesto.html>Español</a><br>
+<a href=/iso/et/manifesto.html>Eesti</a><br>
+<a href=/iso/eu/manifesto.html>Euskara</a><br>
+<a href=/iso/fi/manifesto.html>Suomi</a><br>
+<a href=/iso/fr/manifesto.html>Français</a><br>
+<a href=/iso/ga/manifesto.html>Gaeilge</a><br>
+<a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
+<a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/he/manifesto.html>עברית</a><br>
+<a href=/iso/hi/manifesto.html>हिंदी</a><br>
+<a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
+<a href=/iso/hu/manifesto.html>Hungarian/Magyar</a><br>
+<a href=/iso/id/manifesto.html>Bahasa Indonesia</a><br>
+<a href=/iso/is/manifesto.html>Íslenska</a><br>
+<a href=/iso/it/manifesto.html>Italiano</a><br>
+<a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
+<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/ko/manifesto.html>한국어</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
+<a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
+<a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
+<a href=/iso/ne/manifesto.html>नेपाली</a><br>
+<a href=/iso/nl/manifesto.html>Nederlands</a><br>
+<a href=/iso/no/manifesto.html>Norsk</a><br>
+<a href=/iso/or/manifesto.html>ଓଡ଼ିଆ</a><br>
+<a href=/iso/pa/manifesto.html>ਪੰਜਾਬੀ</a><br>
+<a href=/iso/pl/manifesto.html>Polski</a><br>
+<a href=/iso/pr/manifesto.html>فارسی</a><br>
+<a href=/iso/ptbr/manifesto.html>Português Brasileiro</a><br>
+<a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
+<a href=/iso/ro/manifesto.html>Română</a><br>
+<a href=/iso/ru/manifesto.html>Русский</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sr/manifesto.html>Srpski</a><br>
+<a href=/iso/sv/manifesto.html>Svenska</a><br>
+<a href=/iso/sw/manifesto.html>Swahili</a><br>
+<a href=/iso/ta/manifesto.html>தமிழ்</a><br>
+<a href=/iso/te/manifesto.html>తెలుగు</a><br>
+<a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
+<a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
+<a href=/iso/tr/manifesto.html>Türkçe</a><br>
+<a href=/iso/ts/manifesto.html>Xitsonga</a><br>
+<a href=/iso/uk/manifesto.html>Українська</a><br>
+<a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
+<a href=/iso/yo/manifesto.html>Yoruba</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+</font>
+<br><br>
+
+<font size=1 color=gray>
+site design and artwork &copy; 2001, Ward Cunningham<br>
+Tiếng Việt translation by Dang Thi My Hang @ LIFULL Tech Vietnam
+
+</font>
+
+</center>
+<script src="//www.google-analytics.com/urchin.js"
+type="text/javascript">
+</script>
+<script type="text/javascript">
+_uacct = "UA-2377314-1";
+urchinTracker();
+</script>
+</body>
+</html>

--- a/iso/vi/principles.html
+++ b/iso/vi/principles.html
@@ -1,0 +1,78 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//VI">
+<HTML>
+<HEAD>
+<title>Các guyên tắc đằng sau tuyên ngôn Agile</title>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+</HEAD>
+<BODY background="/background.jpg">
+
+<br><br><br><br>
+<center><h1>Các guyên tắc đằng sau tuyên ngôn Agile</h1></center>
+
+<br><br>
+<center>
+<font size="+2">
+<i>Chúng ta tuân thủ theo các nguyên tắc sau:</i>
+</font>
+
+<p><font size="+2">
+Ưu tiên làm hài lòng khách hàng thông qua việc chuyển giao sớm và liên tục phần mềm có giá trị.
+</font></p>
+
+<p><font size="+2">
+Chào đón việc thay đổi yêu cầu thậm chí là những thay đổi yêu cầu rất muộn. Linh hoạt thay đổi để nâng cao lợi thế cạnh tranh cho khách hàng.
+</font></p>
+
+<p><font size="+2">
+Cố gắng chuyển giao phần mềm chạy được trong thời gian ngắn nhất có thể, thời gian đó là vài ba tuần chứ không nên là vài ba tháng.
+</font></p>
+
+<p><font size="+2">
+Khách hàng của dự án và lập trình viên phải làm việc cùng nhau hằng ngày trong suốt dự án.
+</font></p>
+
+<p><font size="+2">
+Xây dựng dự án bởi những cá nhân có động lực làm việc. Cung cấp cho họ môi trường, sự hỗ trợ cần thiết, và tin tưởng để họ hoàn thành công việc.
+</font></p>
+
+<p><font size="+2">
+Phương pháp truyền đạt thông tin hiệu quả nhất trong nhóm phát triển là nói chuyện trực tiếp với nhau.
+</font></p>
+
+<p><font size="+2">
+Phần mềm chạy tốt là thước đo chính của tiến độ.
+</font></p>
+
+<p><font size="+2">
+Qui trình Agile thúc đẩy phát triển bền vững. Các thành viên của dự án phải duy trì nhịp độ phát triển liên tục.
+</font></p>
+
+<p><font size="+2">
+Không ngừng chú tâm đến kỹ thuật xuất sắc và thiết kế tốt để gia tăng tính linh hoạt.
+</font></p>
+
+<p><font size="+2">
+Sự đơn giản - Nghệ thuật tối đa hóa lượng công việc chưa hoàn thành - là cần thiết.
+</font></p>
+
+<p><font size="+2">
+Kiến trúc tốt nhất, yêu cầu tốt nhất và thiết kế tốt nhất sẽ được tạo ra bởi các nhóm tự tổ chức.
+</font></p>
+
+<p><font size="+2">
+Nhóm phát triển phải luôn suy nghĩ làm sao để tăng hiệu quả hơn nữa, và từ đó điều chỉnh suy nghĩ , hành vi cho phù hợp.
+</font></p>
+
+<br><br><br>
+
+<a href="/iso/vi/manifesto.html">Return to Manifesto</a>
+
+</center>
+<script src="//www.google-analytics.com/urchin.js" type="text/javascript">
+</script>
+<script type="text/javascript">
+_uacct = "UA-2377314-1";
+urchinTracker();
+</script>
+</BODY>
+</HTML>

--- a/iso/xx/manifesto.html
+++ b/iso/xx/manifesto.html
@@ -70,7 +70,75 @@ Dave Thomas<br>
 <br><br>
 
 <font size="+2">
-<a href=/iso/af>Afrikaans</a><br><a href=/iso/sq>Albanian</a><br><a href=/iso/ar>عربي</a><br><a href=/iso/az>Azərbaycanca</a><br><a href=/iso/be>Беларуская</a><br><a href=/iso/bg>Български</a><br><a href=/iso/ca>Català</a><br><a href=/iso/cs>Česky</a><br><a href=/iso/de>Deutsch</a><br><a href=/iso/dk>Dansk</a><br><a href=/iso/el>Ελληνικά</a><br><a href=/iso/en>English</a><br><a href=/iso/es>Español</a><br><a href=/iso/et>Eesti</a><br><a href=/iso/eu>Euskara</a><br><a href=/iso/fi>Suomi</a><br><a href=/iso/fr>Français</a><br><a href=/iso/ka>ქართული</a><br><a href=/iso/he>עברית</a><br><a href=/iso/hi>हिंदी</a><br><a href=/iso/hr>Croatian/Hrvatski</a><br><a href=/iso/hu>Hungarian/Magyar</a><br><a href=/iso/id>Bahasa Indonesia</a><br><a href=/iso/is>Íslenska</a><br><a href=/iso/it>Italiano</a><br><a href=/iso/ja>日本語</a><br><a href=/iso/km>Khmer</a><br><a href=/iso/ko>한국어</a><br><a href=/iso/lv>Latviešu</a><br><a href=/iso/lt>Lietuvių</a><br><a href=/iso/mk>Македонски/Macedonian</a><br><a href=/iso/ms>Bahasa Melayu</a><br><a href=/iso/nl>Nederlands</a><br><a href=/iso/no>Norsk</a><br><a href=/iso/pl>Polski</a><br><a href=/iso/pr>فارسی</a><br><a href=/iso/ptbr>Português Brasileiro</a><br><a href=/iso/ptpt>Português Portugal</a><br><a href=/iso/ro>Română</a><br><a href=/iso/ru>Русский</a><br><a href=/iso/sl>Slovenščina</a><br><a href=/iso/sk>Slovensky</a><br><a href=/iso/sr>Srpski</a><br><a href=/iso/sv>Svenska</a><br><a href=/iso/te>తెలుగు</a><br><a href=/iso/th>ภาษาไทย</a><br><a href=/iso/tl>Filipino</a><br><a href=/iso/tr>Türkçe</a><br><a href=/iso/uk>Українська</a><br><a href=/iso/ur>اردو</a><br><a href=/iso/yo>Yoruba</a><br><a href=/iso/zhcht>繁體中文</a><br><a href=/iso/zhchs>简体中文</a><br>
+<a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/ar/manifesto.html>عربي</a><br>
+<a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
+<a href=/iso/be/manifesto.html>Беларуская</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/ca/manifesto.html>Català</a><br>
+<a href=/iso/cs/manifesto.html>Česky</a><br>
+<a href=/iso/de/manifesto.html>Deutsch</a><br>
+<a href=/iso/dk/manifesto.html>Dansk</a><br>
+<a href=/iso/el/manifesto.html>Ελληνικά</a><br>
+<a href=/>English</a><br>
+<a href=/iso/es/manifesto.html>Español</a><br>
+<a href=/iso/et/manifesto.html>Eesti</a><br>
+<a href=/iso/eu/manifesto.html>Euskara</a><br>
+<a href=/iso/fi/manifesto.html>Suomi</a><br>
+<a href=/iso/fr/manifesto.html>Français</a><br>
+<a href=/iso/ga/manifesto.html>Gaeilge</a><br>
+<a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
+<a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/he/manifesto.html>עברית</a><br>
+<a href=/iso/hi/manifesto.html>हिंदी</a><br>
+<a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
+<a href=/iso/hu/manifesto.html>Hungarian/Magyar</a><br>
+<a href=/iso/id/manifesto.html>Bahasa Indonesia</a><br>
+<a href=/iso/is/manifesto.html>Íslenska</a><br>
+<a href=/iso/it/manifesto.html>Italiano</a><br>
+<a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
+<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/ko/manifesto.html>한국어</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
+<a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
+<a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
+<a href=/iso/ne/manifesto.html>नेपाली</a><br>
+<a href=/iso/nl/manifesto.html>Nederlands</a><br>
+<a href=/iso/no/manifesto.html>Norsk</a><br>
+<a href=/iso/or/manifesto.html>ଓଡ଼ିଆ</a><br>
+<a href=/iso/pa/manifesto.html>ਪੰਜਾਬੀ</a><br>
+<a href=/iso/pl/manifesto.html>Polski</a><br>
+<a href=/iso/pr/manifesto.html>فارسی</a><br>
+<a href=/iso/ptbr/manifesto.html>Português Brasileiro</a><br>
+<a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
+<a href=/iso/ro/manifesto.html>Română</a><br>
+<a href=/iso/ru/manifesto.html>Русский</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sr/manifesto.html>Srpski</a><br>
+<a href=/iso/sv/manifesto.html>Svenska</a><br>
+<a href=/iso/sw/manifesto.html>Swahili</a><br>
+<a href=/iso/ta/manifesto.html>தமிழ்</a><br>
+<a href=/iso/te/manifesto.html>తెలుగు</a><br>
+<a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
+<a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
+<a href=/iso/tr/manifesto.html>Türkçe</a><br>
+<a href=/iso/ts/manifesto.html>Xitsonga</a><br>
+<a href=/iso/uk/manifesto.html>Українська</a><br>
+<a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
+<a href=/iso/yo/manifesto.html>Yoruba</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -88,4 +156,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/xx/manifesto.html
+++ b/iso/xx/manifesto.html
@@ -64,10 +64,6 @@ Dave Thomas<br>
 &copy; 2001, the above authors<br>this declaration may be freely copied in any form, <br>but only in its entirety through this notice
 </font>
 <br><br>
-<font size="+2">
-<a href=principles.html>অ্যাজাইল সফটওয়্যারের বারো নীতিমালা</a><br><br><a href=/sign/signup.cgi>সাক্ষরকারী হয়ে নিন</a><br><a href=/sign/display.cgi>সাক্ষরকারীদের দেখুন</a><br><br><a href=/authors.html>লেখকদের সম্বন্ধে জানুন</a><br><a href=/history.html>ইশতেহার সম্বন্ধে জানুন</a><br><a href="http://www.agilealliance.org/show/2548">ইশতেহার অনুবাদে সাহায্য করুন</a>
-</font>
-<br><br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>

--- a/iso/xx/manifesto.html
+++ b/iso/xx/manifesto.html
@@ -76,7 +76,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/xx/manifesto.html
+++ b/iso/xx/manifesto.html
@@ -101,7 +101,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/xx/manifesto.html
+++ b/iso/xx/manifesto.html
@@ -71,11 +71,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -90,6 +91,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -98,12 +100,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -118,11 +119,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -137,8 +137,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/yo/manifesto.html
+++ b/iso/yo/manifesto.html
@@ -103,7 +103,7 @@ but only in its entirety through this notice.
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/yo/manifesto.html
+++ b/iso/yo/manifesto.html
@@ -128,7 +128,7 @@ but only in its entirety through this notice.
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/yo/manifesto.html
+++ b/iso/yo/manifesto.html
@@ -98,11 +98,12 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -117,6 +118,7 @@ but only in its entirety through this notice.
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -125,12 +127,11 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,11 +146,10 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -164,8 +164,8 @@ but only in its entirety through this notice.
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/yo/manifesto.html
+++ b/iso/yo/manifesto.html
@@ -98,19 +98,17 @@ but only in its entirety through this notice.
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -118,9 +116,7 @@ but only in its entirety through this notice.
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -129,10 +125,12 @@ but only in its entirety through this notice.
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -147,10 +145,11 @@ but only in its entirety through this notice.
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -158,14 +157,15 @@ but only in its entirety through this notice.
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -185,4 +185,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/zh/manifesto.html
+++ b/iso/zh/manifesto.html
@@ -70,7 +70,75 @@ Dave Thomas<br>
 <br><br>
 
 <font size="+2">
-<a href=/iso/en>English</a><br><a href=/iso/es>Español</a><br><a href=/iso/ja>日本語</a><br><a href=/iso/pr>فارسی</a><br><a href=/iso/no>Norsk</a><br><a href=/iso/ptbr>Português Brasileiro</a><br><a href=/iso/sv>Svenska</a><br>
+<a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/ar/manifesto.html>عربي</a><br>
+<a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
+<a href=/iso/be/manifesto.html>Беларуская</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/ca/manifesto.html>Català</a><br>
+<a href=/iso/cs/manifesto.html>Česky</a><br>
+<a href=/iso/de/manifesto.html>Deutsch</a><br>
+<a href=/iso/dk/manifesto.html>Dansk</a><br>
+<a href=/iso/el/manifesto.html>Ελληνικά</a><br>
+<a href=/>English</a><br>
+<a href=/iso/es/manifesto.html>Español</a><br>
+<a href=/iso/et/manifesto.html>Eesti</a><br>
+<a href=/iso/eu/manifesto.html>Euskara</a><br>
+<a href=/iso/fi/manifesto.html>Suomi</a><br>
+<a href=/iso/fr/manifesto.html>Français</a><br>
+<a href=/iso/ga/manifesto.html>Gaeilge</a><br>
+<a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
+<a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/he/manifesto.html>עברית</a><br>
+<a href=/iso/hi/manifesto.html>हिंदी</a><br>
+<a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
+<a href=/iso/hu/manifesto.html>Hungarian/Magyar</a><br>
+<a href=/iso/id/manifesto.html>Bahasa Indonesia</a><br>
+<a href=/iso/is/manifesto.html>Íslenska</a><br>
+<a href=/iso/it/manifesto.html>Italiano</a><br>
+<a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
+<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/ko/manifesto.html>한국어</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
+<a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
+<a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
+<a href=/iso/ne/manifesto.html>नेपाली</a><br>
+<a href=/iso/nl/manifesto.html>Nederlands</a><br>
+<a href=/iso/no/manifesto.html>Norsk</a><br>
+<a href=/iso/or/manifesto.html>ଓଡ଼ିଆ</a><br>
+<a href=/iso/pa/manifesto.html>ਪੰਜਾਬੀ</a><br>
+<a href=/iso/pl/manifesto.html>Polski</a><br>
+<a href=/iso/pr/manifesto.html>فارسی</a><br>
+<a href=/iso/ptbr/manifesto.html>Português Brasileiro</a><br>
+<a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
+<a href=/iso/ro/manifesto.html>Română</a><br>
+<a href=/iso/ru/manifesto.html>Русский</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sr/manifesto.html>Srpski</a><br>
+<a href=/iso/sv/manifesto.html>Svenska</a><br>
+<a href=/iso/sw/manifesto.html>Swahili</a><br>
+<a href=/iso/ta/manifesto.html>தமிழ்</a><br>
+<a href=/iso/te/manifesto.html>తెలుగు</a><br>
+<a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
+<a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
+<a href=/iso/tr/manifesto.html>Türkçe</a><br>
+<a href=/iso/ts/manifesto.html>Xitsonga</a><br>
+<a href=/iso/uk/manifesto.html>Українська</a><br>
+<a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
+<a href=/iso/yo/manifesto.html>Yoruba</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -88,4 +156,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/zh/manifesto.html
+++ b/iso/zh/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html>Twelve Principles of Agile Software</a><br><br><a href=/sign/signup.cgi>Become a Signatory</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
+<a href=principles.html>Twelve Principles of Agile Software</a><br><br><a href=/display/index.html>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br>
 </font>
 <br><br>
 

--- a/iso/zh/manifesto.html
+++ b/iso/zh/manifesto.html
@@ -76,7 +76,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/zh/manifesto.html
+++ b/iso/zh/manifesto.html
@@ -101,7 +101,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/zh/manifesto.html
+++ b/iso/zh/manifesto.html
@@ -71,11 +71,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -90,6 +91,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -98,12 +100,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -118,11 +119,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -137,8 +137,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/zhchs/manifesto.html
+++ b/iso/zhchs/manifesto.html
@@ -96,19 +96,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -116,9 +114,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -127,10 +123,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -145,10 +143,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -156,14 +155,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -183,4 +183,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/iso/zhchs/manifesto.html
+++ b/iso/zhchs/manifesto.html
@@ -126,7 +126,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/zhchs/manifesto.html
+++ b/iso/zhchs/manifesto.html
@@ -101,7 +101,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/zhchs/manifesto.html
+++ b/iso/zhchs/manifesto.html
@@ -96,11 +96,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -115,6 +116,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -123,12 +125,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -143,11 +144,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -162,8 +162,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/zhcht/manifesto.html
+++ b/iso/zhcht/manifesto.html
@@ -93,7 +93,7 @@ Dave Thomas<br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
-<a href=/iso/bg/manifesto.html>български</a><br>
+<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>

--- a/iso/zhcht/manifesto.html
+++ b/iso/zhcht/manifesto.html
@@ -88,11 +88,12 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bg/manifesto.html>Български</a><br>
 <a href=/iso/bs/manifesto.html>Bosanski</a><br>
+<a href=/iso/bg/manifesto.html>български</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
@@ -107,6 +108,7 @@ Dave Thomas<br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -115,12 +117,11 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
+<a href=/iso/lt/manifesto.html>Lietuvių</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -135,11 +136,10 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sa/manifesto.html>संस्कृत</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -154,8 +154,8 @@ Dave Thomas<br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
 <a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 <a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
+<a href=/iso/zhchs/manifesto.html>简体中文</a><br>
 </font>
 <br><br>
 

--- a/iso/zhcht/manifesto.html
+++ b/iso/zhcht/manifesto.html
@@ -118,7 +118,7 @@ Dave Thomas<br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
 <a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
-<a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
+<a href=/iso/km/manifesto.html>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
 <a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>

--- a/iso/zhcht/manifesto.html
+++ b/iso/zhcht/manifesto.html
@@ -88,19 +88,17 @@ Dave Thomas<br>
 
 <font size="+2">
 <a href=/iso/af/manifesto.html>Afrikaans</a><br>
-<a href=/iso/sq/manifesto.html>Albanian</a><br>
-<a href=/iso/am/manifesto.html>Amharic</a><br>
 <a href=/iso/ar/manifesto.html>عربي</a><br>
 <a href=/iso/az/manifesto.html>Azərbaycanca</a><br>
 <a href=/iso/be/manifesto.html>Беларуская</a><br>
-<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/bg/manifesto.html>Български</a><br>
+<a href=/iso/bs/manifesto.html>Bosanski</a><br>
 <a href=/iso/ca/manifesto.html>Català</a><br>
 <a href=/iso/cs/manifesto.html>Česky</a><br>
 <a href=/iso/de/manifesto.html>Deutsch</a><br>
 <a href=/iso/dk/manifesto.html>Dansk</a><br>
 <a href=/iso/el/manifesto.html>Ελληνικά</a><br>
-<a href=/iso/en/manifesto.html>English</a><br>
+<a href=/>English</a><br>
 <a href=/iso/es/manifesto.html>Español</a><br>
 <a href=/iso/et/manifesto.html>Eesti</a><br>
 <a href=/iso/eu/manifesto.html>Euskara</a><br>
@@ -108,9 +106,7 @@ Dave Thomas<br>
 <a href=/iso/fr/manifesto.html>Français</a><br>
 <a href=/iso/ga/manifesto.html>Gaeilge</a><br>
 <a href=/iso/gd/manifesto.html>Gàidhlig</a><br>
-<a href=/iso/gi/manifesto.html>Galician</a><br>
 <a href=/iso/gl/manifesto.html>Galego</a><br>
-<a href=/iso/ka/manifesto.html>ქართული</a><br>
 <a href=/iso/he/manifesto.html>עברית</a><br>
 <a href=/iso/hi/manifesto.html>हिंदी</a><br>
 <a href=/iso/hr/manifesto.html>Croatian/Hrvatski</a><br>
@@ -119,10 +115,12 @@ Dave Thomas<br>
 <a href=/iso/is/manifesto.html>Íslenska</a><br>
 <a href=/iso/it/manifesto.html>Italiano</a><br>
 <a href=/iso/ja/manifesto.html>日本語</a><br>
+<a href=/iso/ka/manifesto.html>ქართული</a><br>
+<a href=/iso/kk/manifesto.html>Қазақ тілі</a><br>
 <a href=/iso/km/manifesto.html/>ខ្មែរ</a><br>
 <a href=/iso/ko/manifesto.html>한국어</a><br>
-<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/lt/manifesto.html>Lietuvių</a><br>
+<a href=/iso/lv/manifesto.html>Latviešu</a><br>
 <a href=/iso/mk/manifesto.html>Македонски/Macedonian</a><br>
 <a href=/iso/ms/manifesto.html>Bahasa Melayu</a><br>
 <a href=/iso/my/manifesto.html>မြန်မာစာ</a><br>
@@ -137,10 +135,11 @@ Dave Thomas<br>
 <a href=/iso/ptpt/manifesto.html>Português Portugal</a><br>
 <a href=/iso/ro/manifesto.html>Română</a><br>
 <a href=/iso/ru/manifesto.html>Русский</a><br>
-<a href=/iso/si/manifesto.html>සිංහල</a><br>
-<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
-<a href=/iso/sk/manifesto.html>Slovensky</a><br>
 <a href=/iso/sa/manifesto.html>संस्कृत</a><br>
+<a href=/iso/si/manifesto.html>සිංහල</a><br>
+<a href=/iso/sk/manifesto.html>Slovensky</a><br>
+<a href=/iso/sl/manifesto.html>Slovenščina</a><br>
+<a href=/iso/sq/manifesto.html>Albanian</a><br>
 <a href=/iso/sr/manifesto.html>Srpski</a><br>
 <a href=/iso/sv/manifesto.html>Svenska</a><br>
 <a href=/iso/sw/manifesto.html>Swahili</a><br>
@@ -148,14 +147,15 @@ Dave Thomas<br>
 <a href=/iso/te/manifesto.html>తెలుగు</a><br>
 <a href=/iso/th/manifesto.html>ภาษาไทย</a><br>
 <a href=/iso/tl/manifesto.html>Filipino</a><br>
+<a href=/iso/tm/manifesto.html>தமிழ்</a><br>
 <a href=/iso/tr/manifesto.html>Türkçe</a><br>
 <a href=/iso/ts/manifesto.html>Xitsonga</a><br>
 <a href=/iso/uk/manifesto.html>Українська</a><br>
 <a href=/iso/ur/manifesto.html>اردو</a><br>
+<a href=/iso/vi/manifesto.html>Tiếng Việt</a><br>
 <a href=/iso/yo/manifesto.html>Yoruba</a><br>
-<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 <a href=/iso/zhchs/manifesto.html>简体中文</a><br>
-
+<a href=/iso/zhcht/manifesto.html>繁體中文</a><br>
 </font>
 <br><br>
 
@@ -174,4 +174,3 @@ urchinTracker();
 </script>
 </body>
 </html>
-

--- a/principles.html
+++ b/principles.html
@@ -3,6 +3,7 @@
 <HEAD>
 <title>Principles behind the Agile Manifesto</title>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=windows-1252">
+<link rel="canonical" href="/principles.html">
 </HEAD>
 <BODY background="/background.jpg">
 


### PR DESCRIPTION
- add Vietnamese Translation pages and links
- fix or remove internal dead links
- add links: /iso/kk/ Kazakh, /iso/tm/ Tamil
- fix or remove external dead links
- add canonical to duplicate pages of original english version /, /iso/en/

memo:
- dupulicaties:
  - /iso/by/ & /iso/be/
  - /iso/ind/ & /iso/id/
  - /iso/ua/ & /iso/uk/
  - /iso/zh/ & /iso/zhchs/
  - /iso/xx/ & /iso/hi/
- dead links
  - thousands of dead links in /display/*