### PR TITLE
Gotten rid of references to signing it

### DIFF
--- a/iso/kk/manifesto.html
+++ b/iso/kk/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html>Agile бағдарламалық қамсыздандырудың он екі қағидасы</a><br><br><a href=/sign/signup.cgi>Become a Signatory</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
+<a href=principles.html>Agile бағдарламалық қамсыздандырудың он екі қағидасы</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
 </font>
 <br><br>
 

--- a/iso/tm/manifesto.html
+++ b/iso/tm/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html>துரித மென்பொருளுக்கான பன்னிரெண்டு கொள்கைகள்</a><br><br><a href=/sign/signup.cgi>Become a Signatory</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
+<a href=principles.html>துரித மென்பொருளுக்கான பன்னிரெண்டு கொள்கைகள்</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
 </font>
 <br><br>
 

--- a/iso/zh/manifesto.html
+++ b/iso/zh/manifesto.html
@@ -65,7 +65,7 @@ Dave Thomas<br>
 </font>
 <br><br>
 <font size="+2">
-<a href=principles.html>Twelve Principles of Agile Software</a><br><br><a href=/sign/signup.cgi>Become a Signatory</a><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
+<a href=principles.html>Twelve Principles of Agile Software</a><br><br><a href=/sign/display.cgi>View Signatories</a><br><br><a href=/authors.html>About the Authors</a><br><a href=/history.html>About the Manifesto</a><br><a href="http://www.agilealliance.org/show/2548">Help us translate the Manifesto</a>
 </font>
 <br><br>
 


### PR DESCRIPTION
There were references to `/sign/signup.cgi` left in the translations.

This gets rid of them