### PR TITLE
Translate "Return to Manifesto" to Japanese

### DIFF
--- a/iso/ja/principles.html
+++ b/iso/ja/principles.html
@@ -65,7 +65,7 @@
 </font></p>
 <br><br><br>
 
-<a href="manifesto.html">Return to Manifesto</a><br>
+<a href="manifesto.html">宣言に戻る</a><br>
 
 </center>
 <script src="http://www.google-analytics.com/urchin.js" type="text/javascript">


### PR DESCRIPTION
"Manifesto for Agile Software Development" translates to "アジャイルソフトウェア開発宣言" in Japanese: https://agilemanifesto.org/iso/ja/manifesto.html

Therefore "Manifesto" is translated as "宣言". It makes the translation consistent.