### PR TITLE
Some text in hindi page was in english. Changed that to devnagri

### DIFF
--- a/iso/hi/manifesto.html
+++ b/iso/hi/manifesto.html
@@ -37,36 +37,33 @@
 </font>
 <br><br><br><br>
 
-<table cellpadding=15><tr align=center valign=top>
-<td><font size="+2">
-<td><font size="+2">
-Kent Beck<br>
-Mike Beedle<br>
-Arie van Bennekum<br>
-Alistair Cockburn<br>
-Ward Cunningham<br>
-Martin Fowler<br>
-</font></td>
-
-<td><font size="+2">
-
-James Grenning<br>
-Jim Highsmith<br>
-Andrew Hunt<br>
-Ron Jeffries<br>
-Jon Kern<br>
-Brian Marick<br>
-</font></td>
-
-<td><font size="+2">
-Robert C. Martin<br>
-
-Steve Mellor<br>
-Ken Schwaber<br>
-Jeff Sutherland<br>
-Dave Thomas<br>
-</font></td>
-</tr></table>
+<table cellpadding=15> <tr align=center valign=top>
+     <td><font size="+2"> 
+        केंट बेक<br>
+         माइक बीडल<br>
+        आरी वान बेनेकम<br>
+         एलिस्टेयर कॉकबर्न<br>
+          वार्ड कनिंघम<br>
+           मार्टिन फौलर<br>
+         </font></td>
+        <td><font size="+2">
+        जेम्स ग्रेनिंग<br>
+        जिम हाईस्मिथ<br>
+        एंड्रू हंट<br>
+        रॉन जेफ्रीज<br>
+        जॉन कर्न<br>
+        ब्रायन मैरिक<br> 
+    </font></td>
+    
+    <td><font size="+2">
+         रॉबर्ट सी. मार्टिन<br>
+        स्टीव मेलर<br>
+         केन स्वाबर<br>
+          जेफ सदरलैंड<br>
+           डेव थॉमस<br> 
+        </font></td>
+    
+    </tr> </table>
 <br><br><br>
 
 <font size=1 color=gray>

--- a/iso/hi/manifesto.html
+++ b/iso/hi/manifesto.html
@@ -38,30 +38,33 @@
 <br><br><br><br>
 
 <table cellpadding=15> <tr align=center valign=top>
-     <td><font size="+2"> 
+    <td><font size="+2"> 
         केंट बेक<br>
-         माइक बीडल<br>
+        माइक बीडल<br>
         आरी वान बेनेकम<br>
-         एलिस्टेयर कॉकबर्न<br>
-          वार्ड कनिंघम<br>
-           मार्टिन फौलर<br>
-         </font></td>
-        <td><font size="+2">
+        एलिस्टेयर कॉकबर्न<br>
+        वार्ड कनिंघम<br>
+        मार्टिन फौलर<br>
+         </font>
+    </td>
+    <td><font size="+2">
         जेम्स ग्रेनिंग<br>
         जिम हाईस्मिथ<br>
         एंड्रू हंट<br>
         रॉन जेफ्रीज<br>
         जॉन कर्न<br>
         ब्रायन मैरिक<br> 
-    </font></td>
+        </font>
+    </td>
     
     <td><font size="+2">
-         रॉबर्ट सी. मार्टिन<br>
+        रॉबर्ट सी. मार्टिन<br>
         स्टीव मेलर<br>
-         केन स्वाबर<br>
-          जेफ सदरलैंड<br>
-           डेव थॉमस<br> 
-        </font></td>
+        केन स्वाबर<br>
+        जेफ सदरलैंड<br>
+        डेव थॉमस<br> 
+        </font>
+    </td>
     
     </tr> </table>
 <br><br><br>
@@ -156,7 +159,7 @@
 <br><br>
 
 <font size=1 color=gray>
-site design and artwork &copy; 2001, Ward Cunningham
+साइट डिज़ाइन एवं कला © 2001, वार्ड कनिंघम
 
 </font>
 


### PR DESCRIPTION
1. Names
2. Copyright notice

The above items were in English for Hindi (devnagri) audience. Hence translated the same to devnagri, so that the intended audience can understand it.